### PR TITLE
[codex] Harden agent card and state templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,16 @@ The user is unlikely to run shell commands themselves. **You** are
 the installer. **You** are the troubleshooter. **You** are the
 ongoing system that grows with the user.
 
+## Agent card startup rule
+
+At every new session start, before the first substantive answer or task action, have startup context: the applicable agent card, `knowledge/state.md`, a recent `knowledge/log.md` slice, active work/open escalations, and a compact incident slice. Prefer the hook-injected `Startup Context Manifest`; when it is present, treat listed slices as already read and do not reread `knowledge/index.md`, full `knowledge/incidents.md`, or the entire backlog just to satisfy startup policy. If the manifest is absent (hook-less runtime), run `~/knowledge/bin/kb-session-start --print --cwd "$PWD"` or manually read: the applicable card (`knowledge/agents/agent-card.md` -> `~/knowledge/agents/agent-card.md` -> explicit no-card fallback), `knowledge/state.md`, `tail -n 80 knowledge/log.md` (fallback 160 when fewer than 3 dated entries are present), active work via `kb-board`, open escalations, and `## Prevention rules` / `## Ongoing` from `knowledge/incidents.md` when present. `knowledge/index.md` and full `knowledge/incidents.md` are on-demand navigation/diagnostics, not startup load. Do not wait for a "who are you" question to load the card; that question only uses the already-read `## Self-introduction`.
+
+## Agent card and state contract
+
+`agent-card.md` is the full startup-loaded project-role passport. Do not intentionally clip it during normal startup. It contains project identity, scope, boundaries, skills, subagents, and runtime notes; generic workflow policy belongs in `AGENTS.md`, not pasted into every card.
+
+`knowledge/state.md` is the current-state dashboard, not a log or archive. Keep it present-tense and overwrite-only: when reality changes, write durable events to `knowledge/log.md` and replace stale state lines. Historical dates, completed work, review/test proof, resolved blockers, and old snapshots belong in `log.md`, `reports/`, `decisions/`, `sources/`, or thematic pages. Current deadlines, active offers, metric timestamps, source freshness, and `Last Updated` dates are allowed.
+
 ## Your role in three sentences
 
 1. **Set up Vepol cleanly on the user's machine** by reading this
@@ -44,6 +54,13 @@ single source of truth and is mutated through `kb-board`, not
 through a database or legacy one-line writer. The universal statuses
 are `Backlog`, `Ready`, `In Progress`, `Blocked`, `Review`, `Done`,
 and `Cancelled`; `Review` is the verification state.
+
+The owner-approved spec gate is mandatory for non-trivial work. The
+path is: research -> owner-approved spec -> `knowledge/spec-approvals.md`
+with exact `spec-contract` hash -> build plan -> RED tests with mandatory E2E path
+-> implementation. Owner approval can be given in chat; the
+agent records it as scribe. Material drift after approval returns to
+spec review and owner approval.
 
 The architecture (which you will install): user's `~/knowledge/`
 holds all knowledge as markdown files; this repo's `bin/` provides

--- a/_template/AGENTS.md
+++ b/_template/AGENTS.md
@@ -20,6 +20,7 @@ _(1–3 предложения: что это, зачем, для кого, в �
 │   ├── raw/                 # immutable источники
 │   │   └── assets/          # картинки
 │   ├── sources/             # саммари raw-документов
+│   ├── agents/              # одна карточка проекта: agent-card.md (общая для всех runtime; identity = роль проекта, не вендор)
 │   └── <категории>/         # специфичные для проекта
 └── <code-dirs>/             # код проекта — сиблинги к knowledge/
 ```
@@ -38,6 +39,22 @@ _(перечислить, какие подпапки в `knowledge/` имеют
 - **Свободно:** создавать/обновлять страницы в `knowledge/`, апдейтить `log.md`, `state.md`, `index.md`.
 - **С подтверждением:** изменения в code-dirs проекта, создание новых категорий в `knowledge/`, удаление страниц.
 - **Никогда:** трогать `knowledge/raw/`, пушить в git без команды, удалять чужие файлы вне `knowledge/`.
+
+## Agent card
+
+В проекте — **одна карточка на роль** (не одна на runtime): `knowledge/agents/agent-card.md`. Identity привязана к роли проекта; Claude Code, Codex, Antigravity CLI и будущие runtime работают по одной и той же карточке. Runtime-различия (что доступно Claude, что — Codex, …) живут в секции `## Operating notes` внутри карточки.
+
+При каждом старте новой сессии — до первого содержательного ответа или действия — агент обязан иметь startup context: agent card, `knowledge/state.md`, свежий срез `knowledge/log.md`, active work/open escalations и компактный incident-срез. Нормальный путь — hook-injected `Startup Context Manifest`; если manifest есть, перечисленные в нём срезы считаются прочитанными, и агент не перечитывает `knowledge/index.md`, полный `knowledge/incidents.md` или весь `knowledge/backlog.md` только ради формальности. Если manifest нет (hook-less runtime), запусти `~/knowledge/bin/kb-session-start --print --cwd "$PWD"` или вручную прочитай: карточку по иерархии `knowledge/agents/agent-card.md` → `~/knowledge/agents/agent-card.md` → явный fallback «карточки нет», `knowledge/state.md`, `tail -n 80 knowledge/log.md` (fallback 160 при <3 датированных записей), active work через `kb-board`, открытые эскалации и `## Prevention rules` / `## Ongoing` из `knowledge/incidents.md` при наличии. `knowledge/index.md` и полный `knowledge/incidents.md` — on-demand навигация/диагностика, не startup load. Вопрос «кто ты / представься» не является триггером чтения: отвечать по уже прочитанному `## Self-introduction`, не generic-описанием вендора. Полная схема — в [`~/knowledge/AGENTS.md`](~/knowledge/AGENTS.md#session-startup-context).
+
+Если карточки в проекте ещё нет — агент явно сообщает об этом и предлагает завести. Образец — `~/knowledge/_template/knowledge/agents/_example.md` (после `new-wiki` он автоматически копируется в `knowledge/agents/_example.md`). Первая операция: `cp knowledge/agents/_example.md knowledge/agents/agent-card.md` и заполнить под проект.
+
+## State contract
+
+`knowledge/state.md` — текущая приборная панель проекта, не лог и не архив. Пиши overwrite-only: когда реальность меняется, записывай событие в `knowledge/log.md` (если оно durable), затем заменяй устаревшую строку в `state.md`. Исторические даты, proof, review results, resolved blockers и старые snapshots уходят в `log.md`, `reports/`, `decisions/`, `sources/` или тематические страницы. Текущие дедлайны, активные офферы, метрики, freshness дат и `Last Updated` допустимы.
+
+## Owner-approved spec gate
+
+For non-trivial work, the path is mandatory: research -> owner-approved spec -> `knowledge/spec-approvals.md` with exact `spec-contract` hash -> build plan -> RED tests with mandatory E2E path -> implementation. The owner can approve in chat; the active agent records the decision as scribe. Any material drift after approval returns to spec review and owner approval.
 
 ## Cross-orchestrator CLI launch
 

--- a/_template/knowledge/agents/_example.md
+++ b/_template/knowledge/agents/_example.md
@@ -1,155 +1,93 @@
 ---
-# Agent card example — copy this file and rename to agent-card.md
-# Filename ЗАФИКСИРОВАН: agent-card.md (одна карточка на роль проекта, не одна на runtime).
-# Identity привязана к роли проекта; Claude Code, Codex, Antigravity CLI работают по одной карточке.
-# Runtime-различия — в секции `## Operating notes` ниже, НЕ в отдельных файлах.
-# Spec: см. мастер-раздел «Agent self-identification» в ~/knowledge/AGENTS.md
-# и (если есть) decisions/agent-card-schema.md в проекте, который ввёл схему.
-#
-# === REQUIRED FIELDS ===
+# Copy this file to `agent-card.md` and fill it for this project role.
+# One project role = one card. Do not create per-runtime cards.
 
-name: "{{PROJECT_SLUG}}"                # slug проекта/роли, lowercase-kebab (например `<your-project>`, не `claude-code`)
-display_name: "{{PROJECT_SLUG}} orchestrator"  # имя РОЛИ, не вендора. Хорошо: «<your-project> orchestrator». Плохо: «Claude Code в <your-project>».
-version: 0.1.0                          # semver карточки; bump patch при любой правке frontmatter
+schema_version: "agent-card/v1"
+inherits: "hub-baseline@0.4.0" # provenance/policy pointer, not runtime merge
 
-# description — это ROUTING TRIGGER, а не human label.
-# Должен начинаться с глагола (use, run, check, handle, …).
-# Это поле читается оркестраторами при выборе агента для делегирования.
-# Плохо:  "Project agent for this project"
-# Хорошо: "Use proactively when working in this project on X — strategy, incidents, ..."
-description: Use proactively when working in this project on its main scope. Do not use for out-of-scope work.
+name: "{{PROJECT_SLUG}}"
+display_name: "{{PROJECT_SLUG}} orchestrator"
+version: "0.1.0"
+description: "Use proactively when working in this project on its main scope. Do not use for out-of-scope work."
 
-role: позиция этой роли в проекте — одна строка (например «dev-meta orchestrator над seed-репо»)
-goal: что роль должна достигать в проекте — одна строка
+role: "<one sentence: what role this agent plays in the project>"
+goal: "<one sentence: what this role tries to achieve>"
 
-# Что агент НЕ делает. Это закрывает over-delegation.
-# Каждая строка — конкретное «нельзя», по возможности с «вместо этого — …».
 boundaries:
-  - не править чувствительные пути без явного подтверждения
-  - не пушить в git без команды; никаких --no-verify / force / hard reset
-  - не трогать knowledge/ других проектов — только через subagent с cwd того проекта
-  - не править хаб-файлы (~/knowledge/registry.md и т.п.) напрямую
-  - не выдумывать пути и значения — проверять реальное состояние перед рекомендацией
+  - "<project-specific boundary; what not to do and where to route instead>"
 
-# Дискретные способности. Каждый skill — отдельная единица работы.
-# Структура совместима с A2A AgentSkill (id/name/description/tags + опционально examples).
 skills:
-  - id: log-incident
-    name: Зафиксировать инцидент
-    description: При любой ошибке или ручной починке — запись в knowledge/incidents.md (симптомы, root cause, фикс, prevention).
-    tags: [incidents, hygiene]
-  - id: spec-driven-implementation
-    name: Spec-driven реализация с ТРИЗ
-    description: Нетривиальная работа около 30+ мин — сначала спека с противоречием и ИКР, потом тесты, потом код.
-    tags: [methodology, triz]
-  - id: cross-agent-review
-    name: Cross-review со вторым оркестратором
-    description: Любой нетривиальный план или спека проходит ревью у второго оркестратора до старта реализации.
-    tags: [methodology, coordination]
-  # — добавляй project-specific skills здесь —
+  - id: "<skill-id>"
+    name: "<skill name>"
+    description: "<when to use it, what it does, what durable output appears>"
+    tags: [project]
 
-# Команда сабагентов роли. Список ОБЩИЙ (не runtime-specific).
-# Runtime-specific roster (что есть у Claude Code, чего нет у Codex, что у Gemini) — в `## Operating notes` body.
-subagents:
-  - name: example-subagent
-    purpose: одна строка когда зовём этого сабагента
-  # — список зависит от проекта —
+subagents: []
 
-# Tools, на которые опирается агент. Список ключевых, не исчерпывающий.
 tools:
-  - Read, Edit, Write
-  - Bash
-  - Agent (subagents)
-  - добавь project-specific
-
-# === OPTIONAL FIELDS (for future A2A export) ===
+  - "<project-specific tool or surface, if any>"
 
 provider:
-  organization: "{{PROJECT_SLUG}}"      # проект, не вендор runtime
-  url: "<project URL, если есть>"
+  organization: "{{PROJECT_SLUG}}"
+  url: "<project URL, if any>"
 
-documentation_url: ../../AGENTS.md      # относительно карточки
-
-# Эти поля заполняй только при появлении HTTP-endpoint и cross-agent дискавери:
-# url: https://<base>/agents/<name>
-# capabilities:
-#   streaming: false
-#   pushNotifications: false
-#   stateTransitionHistory: false
-#   extendedAgentCard: false
-# default_input_modes: [text/plain]
-# default_output_modes: [text/plain]
-# security_schemes: { ... }
+documentation_url: "../../AGENTS.md"
 ---
 
-# {{DISPLAY_NAME — replace with frontmatter.display_name}}
-
-> Это **образец** карточки. Скопируй файл: `cp _example.md agent-card.md`, удали этот блок-предупреждение и заполни поля по проекту.
+# {{PROJECT_SLUG}} orchestrator
 
 ## Self-introduction
 
-Одно-два предложения от первого лица: «Я — <role>. Я занимаюсь <goal>». Этим текстом агент представляется при старте сессии или явном вопросе «кто ты?». Явно отметь: «карточка одна, исполнителей может быть несколько (Claude Code / Codex / Antigravity CLI); runtime-различия — в Operating notes».
+I am the `<project role>` for `{{PROJECT_NAME}}`. My job is `<main responsibility>`.
 
-Хорошо: «Я — dev-meta-оркестратор проекта {{PROJECT_NAME}}. Моя зона — <конкретно что>. Я не <конкретно что>. Карточка одна, исполнителей несколько — Claude Code, Codex, любой будущий runtime.»
-Плохо: «Я — Claude, AI-ассистент от Anthropic.» (generic-описание вендора, identity привязана к runtime)
+This card is shared by all runtimes that work in this project. Runtime differences, if relevant, are listed in `## Operating notes`.
 
 ## Specialization
 
-3-7 строк: на чём агент специализируется **в этом конкретном проекте**, а не вообще. Что отличает работу здесь от работы в других проектах.
+- `<project-specific focus area 1>`
+- `<project-specific focus area 2>`
+- `<project-specific invariant or audience>`
 
-Включить, если применимо:
-- Главные зоны фокуса (с приоритетами).
-- Архитектурные инварианты, которые надо охранять.
-- Особые правила/паттерны проекта.
+Keep this section specific to the project. Generic workflow policy belongs in `AGENTS.md`, not in the card.
 
 ## Skills
 
-Расширение frontmatter.skills — по одному абзацу на скилл: когда применять, что считается входом/выходом, примеры из реальных инцидентов или решений проекта (если уже есть).
+### <skill-id>
 
-### <skill-id-1>
-Триггер: <когда применяется>. Действие: <что делает>. Результат: <что появляется>.
-
-### <skill-id-2>
-…
+Trigger: `<when this skill is used>`.
+Action: `<what the agent does>`.
+Durable output: `<log/report/decision/source/page created or updated>`.
 
 ## Subagents
 
-Кто в команде, на что каждого звать. Зеркалит frontmatter.subagents.
+| Subagent | When to call |
+|----------|--------------|
+| `<name or runtime>` | `<project-specific reason>` |
 
-| Subagent | Когда зову |
-|----------|-----------|
-| `<name>` | <one-line>  |
-
-Параллелизация: независимые задачи спавнятся одним сообщением с несколькими Agent tool calls — не последовательно.
+Use `subagents: []` if this role has no project-specific subagent roster.
 
 ## Boundaries
 
-Расширение frontmatter.boundaries — *почему* и *что делать вместо*.
+### <Boundary title>
 
-### Не <конкретное «нельзя»>
-**Почему:** <обоснование, желательно с inicident-reference>.
-**Вместо:** <что делать в той же ситуации>.
-
-### …
+Why: `<reason this is a real project boundary>`.
+Instead: `<where to route the work or what to do instead>`.
 
 ## Operating notes
 
-Опциональная секция. Любые проектные привычки: где живёт что, куда писать инциденты, какие специальные правила. **Здесь же — runtime-specific notes:** что доступно Claude Code, что — Codex, что — Antigravity CLI. Если нечего сказать — секция опускается.
+Project map:
 
-**Где что искать:**
-- Текущее состояние → `knowledge/state.md`
-- История → `knowledge/log.md`
-- Открытые задачи → `knowledge/backlog.md`
-- Ask-и наверх → `knowledge/escalations.md`
-- Инциденты → `knowledge/incidents.md`
-- Стратегия → `knowledge/strategies.md`
+- Current state: `knowledge/state.md`
+- History: `knowledge/log.md`
+- Open tasks: `knowledge/backlog.md`
+- Escalations: `knowledge/escalations.md`
+- Incidents: `knowledge/incidents.md`
+- Strategy: `knowledge/strategies.md`
 
-**Runtime-specific notes (пример):**
+Runtime notes:
 
-*Claude Code runtime:* доступные subagents — Explore, Plan, general-purpose, codex:codex-rescue; auto-memory в `~/.claude/projects/<project-key>/memory/`; MCP — список релевантных серверов; tools — Read/Edit/Write/Bash/Agent/Skill/WebFetch/WebSearch/TaskCreate-TaskUpdate-TaskList/ScheduleWakeup/Monitor.
+- Claude Code: `<project-specific notes only, if any>`
+- Codex: `<project-specific notes only, if any>`
+- Antigravity CLI: `<project-specific notes only, if any>`
 
-*Codex runtime:* нет Claude Code subagent roster — `subagents: []` для Codex-сессий; прямые tools через `apply_patch` и `exec_command`; web search/fetch, image generation, deferred tool discovery, multi_tool_use.parallel.
-
-*Antigravity CLI runtime:* (заполнить под конкретный проект).
-
-**Версия карточки** инкрементится при любой правке frontmatter (semver patch). Карточку правят только агенты через `@`-mention соответствующего бота в Telegram; человек руками в файл не лезет.
+Do not paste the full CLI matrix, task-board protocol, startup contract, or generic safety policy here. Link to `AGENTS.md` or the relevant KB page instead.

--- a/_template/knowledge/state.md
+++ b/_template/knowledge/state.md
@@ -1,27 +1,40 @@
-# {{PROJECT_NAME}} — текущее состояние
+# {{PROJECT_NAME}} — current state
 
-> Снапшот «где мы сейчас». Обновляется при значимых изменениях. Не лог — здесь только актуальное.
+> Permanent contract: present-tense, overwrite-only. This file answers
+> "where are we right now?" It is not a log, report, proof list, or archive.
+> Historical dates, completed work, review results, test proof, resolved
+> blockers, and old snapshots belong in `log.md`, `reports/`, `decisions/`,
+> `sources/`, or thematic pages. Current deadlines, active offers, metric
+> timestamps, source freshness, and `Last Updated` dates are allowed.
 
-## Одной строкой
+## Current Snapshot
 
-_(что это и в каком состоянии — буквально одно предложение)_
+_(One current statement. Replace it when reality changes. Do not append history.)_
 
-## Ключевые метрики
+## Active Focus
 
-_(таблица: метрика / значение / дата / тренд / источник)_
+_(What is actively being worked or watched now.)_
 
-## Активные гипотезы
+## Key Facts And Constraints
 
-_(что сейчас проверяем, со ссылками на страницы в `experiments/`)_
+_(Current constraints only. Old constraints go to `log.md`, `reports/`, or `decisions/`.)_
 
-## Next steps
+## Next Actions
 
-_(3–7 пунктов, что делаем дальше)_
+_(3-7 current actions. Done items leave state and go to `log.md`.)_
 
-## Open questions
+## Waiting / Blockers
 
-_(что не ясно, что исследовать, где нужны данные)_
+_(Only live blockers. Resolved blockers leave state.)_
 
-## Последнее обновление
+## Open Questions
 
-{{DATE}}
+_(Only unresolved questions. When resolved, remove and log the resolution.)_
+
+## References
+
+_(Links to current canonical decisions/reports/sources; no long summaries.)_
+
+## Last Updated
+
+{{DATE}} — initialized.

--- a/knowledge/AGENTS.md
+++ b/knowledge/AGENTS.md
@@ -1,5 +1,20 @@
 # LLM Wiki Hub — мастер-схема
 
+## Session startup context
+
+При каждом старте новой сессии, до первого содержательного ответа или действия, агент обязан иметь startup context: agent card, `state.md`, recent `log.md`, active work/open escalations и компактный incident-срез.
+
+Нормальный путь — hook `~/knowledge/bin/kb-session-start`, который отдаёт markdown bundle с `## Startup Context Manifest`. Если manifest уже есть во входном контексте:
+
+- считать перечисленные slices уже прочитанными;
+- не перечитывать `knowledge/index.md`, полный `knowledge/incidents.md` или весь `knowledge/backlog.md` только ради формальности;
+- использовать `knowledge/index.md` только on-demand для навигации/поиска релевантных страниц;
+- открывать полный `knowledge/incidents.md` только для диагностики, risky work или когда startup-срез указывает на ongoing incident.
+
+Если manifest нет (hook-less runtime), запусти `__HOME__/knowledge/bin/kb-session-start --print --cwd "$PWD"` перед содержательной работой. Ручной fallback, если скрипт недоступен: прочитать agent card по иерархии `knowledge/agents/agent-card.md` → `~/knowledge/agents/agent-card.md` → явный fallback «карточки нет», `knowledge/state.md`, последние **80 физических строк** `knowledge/log.md` (`tail -n 80`, расширить до 160 если в 80 строках меньше 3 датированных записей `## [`), active work через `kb-board`, открытые эскалации и только `## Prevention rules` / `## Ongoing` из `knowledge/incidents.md` при наличии.
+
+Вопрос «кто ты / представься» не является триггером чтения карточки или лога: к этому моменту startup context уже должен быть прочитан. Число 80 выбрано по локальному замеру 24 реальных project logs: `tail -20` даёт медиану 8 свежих событий, `tail -40` — 14, `tail -80` — 20; `tail -120/160` заметно раздувает контекст без пропорциональной пользы.
+
 Это центральный хаб персональной базы знаний («второй мозг»). Паттерн — [Karpathy LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): LLM инкрементально строит и поддерживает связный набор markdown-файлов, человек курирует источники и задаёт вопросы.
 
 ## Telegram messaging — mention placement (hard rule)
@@ -84,9 +99,22 @@ Rules:
 - `Review` is the testing/verification state; do not create separate `Testing` or `Verification` sections.
 - Run `kb-board check <backlog.md>` before ending substantive board work.
 
+### Owner-approved spec gate
+
+For non-trivial work, the path is mandatory: research -> owner-approved spec -> `knowledge/spec-approvals.md` with exact `spec-contract` hash -> build plan -> RED tests with mandatory E2E path -> implementation. The owner can approve in chat; the active agent records the decision as scribe. Any material drift after approval returns to spec review and owner approval.
+
 **`strategies.md`** — «куда двигаемся и почему» + проверяемые гипотезы о собственной работе агента. Обновляется самим проектом (не хабом): раз в неделю через skill `agent-review` (когда он появится), или при значимом pivot'е. Формат — в `_template/knowledge/strategies.md`. Конвенция лога для стратегии/гипотез/экспериментов: `## [YYYY-MM-DD] strategy | <project> | ...`, `## [YYYY-MM-DD] hypothesis | <project> | ...`, `## [YYYY-MM-DD] experiment | <project> | start|result | ...`.
 
 **`agents/`** — карточка роли проекта. Полная схема, имя файла, поведение при старте сессии, иерархия project→baseline→generic, multi-orchestrator edit protocol — в разделе [«Agent self-identification»](#agent-self-identification) ниже. Короткая версия: **один файл `agent-card.md` на проект**, идентичность привязана к роли (а не к runtime), runtime-различия (Claude Code / Codex / Antigravity CLI) живут в секции `## Operating notes` внутри карточки.
+
+### State contract
+
+`state.md` — текущая приборная панель проекта, не лог и не архив. Он отвечает на вопрос: **где мы сейчас?**
+
+- Писать в настоящем времени, overwrite-only: когда реальность меняется, заменить устаревшую строку.
+- Исторические даты, `since`, `fixed`, `shipped`, test proof, review result, incident narrative, resolved blockers and old snapshots go to `log.md`, `reports/`, `decisions/`, `strategies.md`, `sources/`, or entity pages.
+- Current dates are allowed for `Last Updated`, active deadlines, active offers, metric timestamps, and source freshness.
+- State edit rule: first record the event in `log.md` when it matters, then leave only the current truth in `state.md`.
 
 **Ключевое правило**: всё, что LLM пишет или читает как «знание», живёт внутри `knowledge/`. Всё, что является рабочим кодом/контентом/артефактом — сиблинги к `knowledge/`.
 
@@ -189,7 +217,7 @@ Acceptance — ответ должен содержать все эти подс
 Из этого следуют жёсткие правила:
 
 - Нет отдельной памяти под каждого оркестратора. Источник правды всегда один: `~/knowledge/` и проектные `knowledge/`.
-- Любой агент перед работой читает тот же curated context, который читал бы Claude через SessionStart: `README.md`, `state.md`, `index.md`, свежий `log.md`, при необходимости `backlog.md`, `escalations.md`, `incidents.md`, recent `daily/`.
+- Любой агент перед работой использует тот же startup bundle, который формирует `kb-session-start`: agent card, project state, recent log, active work/open escalations, compact prevention/ongoing incident slice, CLI roster/recent daily при наличии. Если bundle уже пришёл с `Startup Context Manifest`, эти срезы считаются прочитанными; `index.md` и полный `incidents.md` открываются on-demand.
 - Любой агент после значимой работы обязан оставить след в той же системе: `log.md` для событий и решений, `state.md` для изменившегося статуса, тематические страницы для нового знания, `incidents.md` для поломок и ручных обходов.
 - Если у конкретного инструмента нет автоматических хуков SessionStart/SessionEnd, агент компенсирует это вручную. Отсутствие автоматики не освобождает от дисциплины памяти.
 - Цель — **zero split-brain**: любой второй оркестратор должен уметь продолжить работу только по файлам, без доступа к прошлому чату.
@@ -204,7 +232,9 @@ Acceptance — ответ должен содержать все эти подс
 
 ## Agent self-identification
 
-«Карточка агента» = одна Markdown-страница, где описана **роль проекта**: что я тут делаю, на чём специализируюсь, какие у меня скиллы, кого зову как сабагентов, чего не делаю. При старте сессии любой оркестратор обязан прочитать эту карточку до первого ответа; на вопрос «кто ты / представься» отвечает по `## Self-introduction` карточки, а не generic-описанием вендора.
+«Карточка агента» = одна Markdown-страница, где описана **роль проекта**: что я тут делаю, на чём специализируюсь, какие у меня скиллы, кого зову как сабагентов, чего не делаю. При каждом старте новой сессии любой оркестратор обязан найти и прочитать карточку по иерархии ниже до первого содержательного ответа. Это не ленивое действие по вопросу «кто ты / представься»: такой вопрос только использует уже прочитанный `## Self-introduction` карточки вместо generic-описания вендора.
+
+`agent-card.md` — полный startup-loaded паспорт роли проекта. Его нельзя намеренно резать при нормальной работе. Generic process policy belongs in `AGENTS.md`; the card contains project-specific identity, scope, boundaries, skills, subagents, and runtime deltas. `inherits: hub-baseline@<version>` is a provenance/policy pointer, not runtime merge semantics: if project card exists, it still must stand alone.
 
 Этот раздел — единственный канон конвенции для всех проектов на машине.
 
@@ -223,6 +253,8 @@ Acceptance — ответ должен содержать все эти подс
 
 | Поле | Тип | Назначение |
 |------|-----|-----------|
+| `schema_version` | string | card schema marker for new cards, currently `agent-card/v1` |
+| `inherits` | string | provenance/policy pointer such as `hub-baseline@0.4.0`; not runtime merge |
 | `name` | string (slug) | id проекта/роли в `knowledge/agents/`, lowercase-kebab, совпадает с `<slug>` или `<slug>-<role>` |
 | `display_name` | string | человекочитаемое имя роли («example-project orchestrator», не «Claude Code в example-project») |
 | `version` | string | semver карточки, **bump patch при любой правке frontmatter** |
@@ -242,7 +274,7 @@ Acceptance — ответ должен содержать все эти подс
 # <display_name>
 
 ## Self-introduction
-Одно-два предложения от первого лица: «Я — <role>. Я занимаюсь <goal>». Этим текстом агент представляется при старте сессии или явном вопросе «кто ты?». Явно отметить: «карточка одна, исполнителей может быть несколько; runtime-различия — в Operating notes».
+Одно-два предложения от первого лица: «Я — <role>. Я занимаюсь <goal>». После обязательного стартового чтения карточки этот текст используется как canonical self-introduction, в том числе для явного вопроса «кто ты?». Явно отметить: «карточка одна, исполнителей может быть несколько; runtime-различия — в Operating notes».
 
 ## Specialization
 3-7 строк: на чём агент специализируется **именно в этом проекте** (не вообще). Что отличает работу здесь от работы в других проектах на машине.
@@ -279,9 +311,9 @@ Acceptance — ответ должен содержать все эти подс
 3. **Conflict resolution.** Если два оркестратора правят одновременно и файл показывает конфликт — никто не перезаписывает молча. Конфликт фиксируется в `knowledge/incidents.md` строкой `agent-card conflict: <runtime>, <date>, <fields>`, resolution обсуждается человеком или эскалируется в `escalations.md`.
 4. **Ownership.** В первой версии нет formal ownership: любой оркестратор может править карточку. Закреплять «Codex владеет X, Claude — Y» — только при появлении реальных конфликтов, не раньше.
 
-### Reliability escalation
+### Startup enforcement
 
-Если хотя бы **одна свежая сессия** регрессит (представляется generic-описанием вендора при наличии карточки) — поднимается обязательный SessionStart-hook, читающий `agent-card.md` и кладущий её содержимое в системный контекст до первого turn'а. До регрессии — мастер-правила здесь и в `~/.claude/CLAUDE.md` достаточно.
+Чтение `agent-card.md` при старте — обязательный startup contract, не troubleshooting escalation. Runtime'ы с SessionStart-hook должны класть найденную карточку в системный контекст до первого turn'а. Runtime'ы без hook'а обязаны прочитать карточку напрямую в начале сессии, до ответа пользователю или выполнения задачи. На вопрос «кто ты / представься» нельзя впервые загружать карточку: к этому моменту она уже должна быть прочитана, либо отсутствие карточки должно быть явно зафиксировано.
 
 ### Failure modes
 
@@ -290,6 +322,7 @@ Acceptance — ответ должен содержать все эти подс
 | Карточка отсутствует | Identity-drift | При старте — агент явно говорит «карточки нет, завести?» |
 | `description` — лейбл, не trigger | Auto-delegation не работает | Lint `kb-doctor agent-cards` (future): проверка что `description` начинается с глагола |
 | Карточка дублирует `AGENTS.md` | Drift между двумя источниками | `AGENTS.md` ссылается на карточку, не дублирует |
+| Карточка копирует generic policy вместо project identity | Card bloat, stale duplicated rules | Replace copied policy with a link or `inherits`; keep only project-specific meaning |
 | Per-runtime файлы (legacy) | Split-brain между Claude и Codex | Смержить в `agent-card.md`, удалить старые файлы, version bump, запись в `log.md` |
 | Карточка привязана к вендору в `display_name` («Codex — X») | Identity ломается при смене runtime | `display_name` = роль проекта; вендор — только в `## Operating notes` |
 | Frontmatter ломает YAML | Карточку не прочитать | `python -c "import yaml; yaml.safe_load(open('....md').read().split('---')[1])"` |
@@ -443,7 +476,7 @@ Vault открывается **на уровне `~/knowledge/`**. Благод�
 
 В проектах, где уже есть `<project>/knowledge/log.md`, Codex и Claude Code сессии **автоматически захватываются** через [coleam00/claude-memory-compiler](https://github.com/coleam00/claude-memory-compiler). Antigravity CLI (`agy`) хука пока не имеет — после стабилизации экосистемы (curl-installed v1.0.0 from 2026-05-19) добавить аналогичный adapter:
 
-**SessionStart** — хук `~/knowledge/bin/kb-session-start` читает `README.md`, `state.md`, `index.md`, последние 80 строк `log.md` и последние `daily/YYYY-MM-DD.md`, отдаёт как `additionalContext` в новую сессию. Claude начинает работу, уже «помня» контекст проекта.
+**SessionStart** — хук `~/knowledge/bin/kb-session-start` формирует manifest-aware startup bundle: agent card, `state.md`, recent `log.md`, active work/open escalations, compact prevention/ongoing incident slice, CLI roster/recent `daily/` при наличии бюджета. `index.md` и полный `incidents.md` не грузятся на старте; они остаются on-demand навигацией/диагностикой.
 
 **SessionEnd / PreCompact** — хуки `kb-session-end` / `kb-pre-compact` экспортят:
 - `CLAUDE_KB_DAILY_DIR=<project>/knowledge/daily`


### PR DESCRIPTION
## Summary
- make agent cards explicit `agent-card/v1` startup-loaded project-role passports
- replace the new-project state template with a permanent overwrite-only current-state dashboard contract
- add the state/card contract to public root/template/hub AGENTS surfaces so fresh installs inherit it

## Validation
- `python3` YAML/schema checks for `_template/knowledge/agents/_example.md`: OK
- isolated `new-wiki` render against a temp hub: OK
- `kb-session-start --print --cwd /Users/macbook/vepol-dev`: `agent_card: included`
- `/Users/macbook/knowledge/bin/kb-seed-sync`: leak-scan clean; seed-content-audit P0=0 P1=0 P2=0 info=0
- `VEPOL_SKIP_LLM=1 ./tests/run-all.sh` in clean worktree: fails on untouched `tests/install/agent-modes.sh` synthetic HOME setup (`knowledge/bin`, `knowledge/orchestrator-seed`, `knowledge/personal` missing); no diff to `install.sh` or that test in this PR
