### PR TITLE
Use independent digest channel flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ upgrading.
 
 ## [Unreleased]
 
+### Changed
+- **Digest audio uses independent channel flags.** `outputs` is now one boolean
+  map. Every `true` channel receives the same frozen speech text; `false` means
+  no call. Telegram and NotebookLM can run together, and adding a future channel
+  no longer requires a whitelist of backend combinations. The old
+  `--audio-backend` selector is removed.
+
 ## [0.7.0] — 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ unit tests. The list grows release by release; see
   process — `id`, `enabled`, `when`, `run`, `outputs` — and one file
   to read to see which routines run on your machine. Background runs
   are text-first by default. The two exact daily digest commands may send the
-  finalized text either to NotebookLM Audio Overview or to the on-demand Qwen
-  runtime followed by Telegram; other scheduled commands remain fail-closed.
-  Fresh installs default to NotebookLM, while local Qwen is an explicit choice
-  that runs `kb-tts-install`; the model exits after each render instead of
-  running as a service. A missing config self-heals with safe defaults.
+  finalized text to every enabled audio channel. One boolean `outputs` map is
+  the only delivery setting: each `true` channel runs independently. Telegram
+  uses the on-demand Qwen runtime; NotebookLM creates an Audio Overview. Other
+  scheduled commands remain fail-closed. A missing config self-heals with safe
+  defaults.
 
 - **Idea Intake** — an event-driven process for ideas you write or dictate:
   `kb-idea capture` creates canonical markdown cards under `personal/ideas/`,
@@ -290,25 +290,19 @@ kb-demo brief          # see what a synthesized brief looks like
 
 That's the value loop. Methodology comes after, when you want it.
 Daily research delivers text out of the box. Morning/evening digest text is
-generated the same way for both audio routes. Choose where that finished text
-goes:
+generated once, then sent to every channel whose flag is `true`:
 
-```bash
-# Audio Overview remains in NotebookLM; nothing is sent to Telegram.
-kb-digest-migrate --file ~/knowledge/personal/processes.yaml --audio-backend notebooklm
-
-# Or render locally with Qwen and send the MP3 to Telegram.
-kb-tts-install
-kb-digest-migrate --file ~/knowledge/personal/processes.yaml --audio-backend local_qwen
+```yaml
+outputs: {file: true, telegram_audio: true, notebooklm_audio: true}
 ```
 
-For Qwen, configure `TELEGRAM_BOT_TOKEN` (or `TELEGRAM_TOKEN`) plus
+Set a channel to `false` to disable it. For Telegram, run `kb-tts-install` and
+configure `TELEGRAM_BOT_TOKEN` (or `TELEGRAM_TOKEN`) plus
 `TELEGRAM_CHAT_ID` in `~/knowledge/personal/.secrets`. Nothing stays running:
 Qwen loads for one render, sends the MP3, and exits. For NotebookLM,
 authenticate with `notebooklm login && notebooklm status`; the Audio Overview
-stays there and is not downloaded. The installer exposes the same choice via
-`--audio-backend notebooklm|local_qwen`; upgrades without that option preserve
-the existing route. The default research topic is automatic; use
+stays there and is not downloaded. Upgrades preserve the existing output flags.
+The default research topic is automatic; use
 `kb-daily-research --set-topic "..."` only when you want to steer it.
 
 ## Status

--- a/bin/_kb_digest_migrate.py
+++ b/bin/_kb_digest_migrate.py
@@ -8,11 +8,10 @@ conditions; else `after:daily` — so the digest never misses an enabled morning
 process or races it as a sibling.
 
 Managed re-anchor (spec D6): when `morning-digest` already exists and its block
-is MANAGED — run equals the allowlisted digest command (basename-normalized),
-outputs are exactly `[file, telegram_audio]` or `[file, notebooklm_audio]`, and
-`when` is one of this migration's own anchors — a re-run recomputes the anchor
-and changes the route only when explicitly requested. A customized
-block (any other run/outputs/when) is left byte-identical and reported as a
+is MANAGED — run equals the allowlisted digest command (basename-normalized)
+and `when` is one of this migration's own anchors — a re-run recomputes the
+anchor without caring which independent channel flags are enabled. A customized
+block (any other run/when) is left byte-identical and reported as a
 notice, never rewritten. This is what makes
 "enable money-radar later, re-run kb-digest-migrate" mechanically true.
 
@@ -49,11 +48,7 @@ from _kb_mail.migrate import (  # noqa: E402
 _MORNING_RUN = SCHEDULED_TELEGRAM_AUDIO_ALLOWED["morning-digest"]
 _EVENING_RUN = SCHEDULED_TELEGRAM_AUDIO_ALLOWED["evening-digest"]
 _MANAGED_ANCHORS = ("after:money-radar", "after:learning", "after:daily")
-_BACKEND_OUTPUTS = {
-    "notebooklm": ["file", "notebooklm_audio"],
-    "local_qwen": ["file", "telegram_audio"],
-}
-_MANAGED_OUTPUTS = tuple(_BACKEND_OUTPUTS.values())
+_DEFAULT_OUTPUTS = ["file", "notebooklm_audio"]
 
 
 class DigestMigrationError(Exception):
@@ -69,8 +64,17 @@ def _digest_block(pid: str, when: str, run: str, outputs: list[str]) -> list[str
         "  enabled: true",
         f"  when: {when}",
         f"  run: {run}",
-        f"  outputs: [{', '.join(outputs)}]",
+        f"  outputs: {_format_outputs(outputs)}",
     ]
+
+
+def _format_outputs(outputs: list[str]) -> str:
+    return (
+        "{file: true, "
+        f"telegram_audio: {'true' if 'telegram_audio' in outputs else 'false'}, "
+        f"notebooklm_audio: {'true' if 'notebooklm_audio' in outputs else 'false'}"
+        "}"
+    )
 
 
 def _morning_anchor(pmap: dict) -> str:
@@ -91,29 +95,16 @@ def _morning_anchor(pmap: dict) -> str:
 def _is_managed(p: dict, run: str, anchors: tuple[str, ...]) -> bool:
     return (
         normalized_run_argv(p["run"]) == normalized_run_argv(run)
-        and p["outputs"] in _MANAGED_OUTPUTS
         and p["when"] in anchors
     )
 
 
-def _set_outputs(lines: list[str], start: int, outputs: list[str]) -> None:
-    """Set only the outputs line inside one validated managed block."""
-    _start, end, _blank = _block_span(lines, start)
-    for idx in range(start + 1, end):
-        if lines[idx].startswith("  outputs:"):
-            lines[idx] = f"  outputs: [{', '.join(outputs)}]"
-            return
-    raise DigestMigrationError("managed digest block has no outputs field")
-
-
 def _parse_source(text: str) -> list[dict]:
-    """Validate a source containing either canonical managed audio route."""
+    """Validate the source before any text surgery."""
     return parse_processes_text(text)
 
 
-def migrate_processes(
-    text: str, audio_backend: str | None = None,
-) -> tuple[str, list[str]]:
+def migrate_processes(text: str) -> tuple[str, list[str]]:
     """Return (migrated text, notices).
 
     Fail-closed: invalid input raises ProcessConfigError, an unmigratable-but-
@@ -121,11 +112,6 @@ def migrate_processes(
     returned byte-for-byte unchanged (idempotent, including right after a
     managed re-anchor).
     """
-    if audio_backend is not None and audio_backend not in _BACKEND_OUTPUTS:
-        raise DigestMigrationError(
-            "audio_backend must be 'notebooklm' or 'local_qwen'"
-        )
-    selected_outputs = _BACKEND_OUTPUTS[audio_backend or "notebooklm"]
     procs = _parse_source(text)
     pmap = {p["id"]: p for p in procs}
     notices: list[str] = []
@@ -144,17 +130,15 @@ def migrate_processes(
     morning = pmap.get("morning-digest")
     if morning is None:
         appends.append(_digest_block(
-            "morning-digest", anchor, _MORNING_RUN, selected_outputs,
+            "morning-digest", anchor, _MORNING_RUN, _DEFAULT_OUTPUTS,
         ))
     elif _is_managed(morning, _MORNING_RUN, _MANAGED_ANCHORS):
         if morning["when"] != anchor:
             # Managed re-anchor: ONLY the when: line changes (spec D6).
             _set_when(lines, blocks["morning-digest"].when, anchor)
-        if audio_backend is not None and morning["outputs"] != selected_outputs:
-            _set_outputs(lines, blocks["morning-digest"].start, selected_outputs)
     else:
         notices.append(
-            "morning-digest exists but is customized (run/outputs/when differ "
+            "morning-digest exists but is customized (run/when differ "
             "from the managed block); left untouched — re-anchor it by hand if "
             "you want it behind the newest morning process"
         )
@@ -162,14 +146,13 @@ def migrate_processes(
     evening = pmap.get("evening-digest")
     if evening is None:
         appends.append(_digest_block(
-            "evening-digest", "after:retro", _EVENING_RUN, selected_outputs,
+            "evening-digest", "after:retro", _EVENING_RUN, _DEFAULT_OUTPUTS,
         ))
     elif _is_managed(evening, _EVENING_RUN, ("after:retro",)):
-        if audio_backend is not None and evening["outputs"] != selected_outputs:
-            _set_outputs(lines, blocks["evening-digest"].start, selected_outputs)
+        pass
     else:
         notices.append(
-            "evening-digest exists but is customized (run/outputs/when differ "
+            "evening-digest exists but is customized (run/when differ "
             "from the managed block); left untouched"
         )
 

--- a/bin/_kb_processes.py
+++ b/bin/_kb_processes.py
@@ -25,14 +25,14 @@ CLOSED (config rejected) — it is never silently ignored.
 
 `outputs` semantics: telegram/people/calendar are user-facing channels;
 `file` is internal agent memory and never counts as user delivery;
-`notebooklm_audio` and `telegram_audio` may be scheduled only for the explicit
-digest processes in SCHEDULED_TELEGRAM_AUDIO_ALLOWED, each bound to its EXACT
-run command and exactly one canonical `[file, <audio>]` pair. Any other
-scheduled audio declaration fails closed.
+`outputs` accepts the legacy list or a boolean map. In a map, every `true`
+channel is enabled independently and every `false` channel is omitted.
+Scheduled audio remains bound to the explicit digest process id + run command;
+there is no whitelist of channel combinations.
 
 The file is a strict, hand-parseable YAML subset: blank lines, full-line
 `#` comments, blocks starting with `- id: <id>`, fields indented exactly
-two spaces, inline `[a, b]` lists. Parsed with stdlib only — this module
+two spaces, inline `[a, b]` lists or `{channel: true}` maps. Parsed with stdlib only — this module
 sits on the launchd-critical path (kb-tick) and must not depend on
 PyYAML being importable by whatever python3 launchd resolves.
 
@@ -139,22 +139,21 @@ DEFAULT_PROCESSES_YAML = """\
   run: kb-learning-arxiv --text-only
   outputs: [telegram, file]
 
-# Selectable audio digests (morning recap + short evening retro recap).
-# Backward-compatible fresh-install default is NotebookLM; use
-# kb-digest-migrate --audio-backend local_qwen after kb-tts-install to switch.
+# Audio digests use one boolean map: every true channel is called independently.
+# Fresh-install defaults preserve the previous NotebookLM-only behavior.
 # If you later enable money-radar, re-run kb-digest-migrate to re-anchor the
 # morning digest behind it.
 - id: morning-digest
   enabled: true
   when: after:learning
   run: kb-morning-digest
-  outputs: [file, notebooklm_audio]
+  outputs: {file: true, telegram_audio: false, notebooklm_audio: true}
 
 - id: evening-digest
   enabled: true
   when: after:retro
   run: kb-morning-digest --period evening
-  outputs: [file, notebooklm_audio]
+  outputs: {file: true, telegram_audio: false, notebooklm_audio: true}
 
 # Telegram people collector (People Notebook): aggregates WHO wrote in
 # private dialogs into a daily identity envelope — names/usernames/counts
@@ -306,14 +305,42 @@ def parse_processes_text(text: str) -> list[dict]:
         p["run"] = run
 
         out_raw = p["outputs"].strip()
-        m = re.match(r"^\[(.*)\]$", out_raw)
-        if not m:
+        list_match = re.match(r"^\[(.*)\]$", out_raw)
+        map_match = re.match(r"^\{(.*)\}$", out_raw)
+        if list_match:
+            inner = list_match.group(1).strip()
+            items = [_strip_quotes(x) for x in inner.split(",")] if inner else []
+        elif map_match:
+            inner = map_match.group(1).strip()
+            items = []
+            seen: set[str] = set()
+            for entry in inner.split(",") if inner else []:
+                if ":" not in entry:
+                    raise ProcessConfigError(
+                        f"process {pid!r}: output flags must be key: true|false"
+                    )
+                key_raw, enabled_raw = entry.split(":", 1)
+                key = _strip_quotes(key_raw.strip())
+                enabled = _strip_quotes(enabled_raw.strip())
+                if key in seen:
+                    raise ProcessConfigError(f"process {pid!r}: duplicate output {key!r}")
+                seen.add(key)
+                if key not in ALLOWED_OUTPUTS:
+                    raise ProcessConfigError(
+                        f"process {pid!r}: unknown output {key!r} "
+                        f"(allowed: {list(ALLOWED_OUTPUTS)})"
+                    )
+                if enabled not in ("true", "false"):
+                    raise ProcessConfigError(
+                        f"process {pid!r}: output {key!r} must be true or false"
+                    )
+                if enabled == "true":
+                    items.append(key)
+        else:
             raise ProcessConfigError(
-                f"process {pid!r}: outputs must be an inline list like "
-                f"[telegram, file], got {out_raw!r}"
+                f"process {pid!r}: outputs must be an inline list or boolean map, "
+                f"got {out_raw!r}"
             )
-        inner = m.group(1).strip()
-        items = [_strip_quotes(x) for x in inner.split(",")] if inner else []
         if not items or any(not it for it in items):
             raise ProcessConfigError(
                 f"process {pid!r}: outputs must be a non-empty list"
@@ -383,14 +410,6 @@ def parse_processes_text(text: str) -> list[dict]:
                     f"allowed for the managed digest processes "
                     f"{sorted(SCHEDULED_TELEGRAM_AUDIO_ALLOWED)} with their exact "
                     f"run commands; others must be on-demand"
-                )
-            if p["outputs"] not in (
-                ["file", "notebooklm_audio"], ["file", "telegram_audio"]
-            ):
-                raise ProcessConfigError(
-                    f"process {p['id']!r}: managed scheduled digest outputs must "
-                    "be exactly [file, notebooklm_audio] or "
-                    "[file, telegram_audio]"
                 )
 
     # after:* chains must be acyclic, else dependents would deadlock silently.

--- a/bin/kb-digest-migrate
+++ b/bin/kb-digest-migrate
@@ -16,7 +16,7 @@ Spec: decisions/local-tts-v0-6-dual-backend-addendum-2026-07-11.md
       (spec-contract:sha256:64c99d1d0e31cc701bcedcbe371b603ef179991db5ab508a17abb31ea8d99062)
 
 Usage:
-  kb-digest-migrate --file <path> [--audio-backend notebooklm|local_qwen] [--revert]
+  kb-digest-migrate --file <path> [--revert]
 """
 from __future__ import annotations
 
@@ -62,11 +62,6 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--file", required=True, help="path to processes.yaml")
     ap.add_argument("--revert", action="store_true",
                     help="undo the migration (remove both digest blocks)")
-    ap.add_argument(
-        "--audio-backend", choices=("notebooklm", "local_qwen"),
-        help=("selected managed digest route; omitted preserves existing managed "
-              "routes and defaults newly created blocks to notebooklm"),
-    )
     args = ap.parse_args(argv)
 
     try:
@@ -82,9 +77,7 @@ def main(argv: list[str]) -> int:
         if args.revert:
             result = revert_processes(text)
         else:
-            result, notices = migrate_processes(
-                text, audio_backend=args.audio_backend,
-            )
+            result, notices = migrate_processes(text)
     except (ProcessConfigError, DigestMigrationError) as exc:
         verb = "revert" if args.revert else "migrate"
         print(

--- a/bin/kb-morning-digest
+++ b/bin/kb-morning-digest
@@ -1263,9 +1263,9 @@ def load_notebooklm_manifest(path: pathlib.Path) -> dict[str, Any]:
         value = json.loads(path.read_text(encoding="utf-8"))
         if not isinstance(value, dict):
             return {}
-        # A local-Qwen manifest owns a different counter/state schema. An
-        # explicit route switch starts a fresh NotebookLM adapter state instead
-        # of coercing its attempts dict or treating its completed send as ours.
+        # A local-Qwen manifest owns a different counter/state schema. Ignore it
+        # instead of coercing its attempts dict or treating its completed send
+        # as NotebookLM state.
         if value.get("delivery") == DELIVERY_TAG or isinstance(value.get("attempts"), dict):
             return {}
         return value

--- a/bin/kb-morning-digest
+++ b/bin/kb-morning-digest
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""kb-morning-digest — unchanged digest text with selectable audio delivery.
+"""kb-morning-digest — one digest dispatched to independently enabled channels.
 
 Design (owner directive 2026-06-25): every morning, gather the freshest output of
 each orchestrator process (arxiv research, money radar, daily brief, daily
 research, idea digest, project state/board, hub log/escalations) into ONE
 digest file, derive a speech-only text file, render it through the pinned local
-Qwen runtime on demand and send the MP3 to Telegram, or pass the same ready
-digest to NotebookLM. The selected route comes from KB_PROCESS_OUTPUTS.
+Qwen runtime on demand and send the MP3 to Telegram, and/or pass the same ready
+digest to NotebookLM. Every true output flag is dispatched independently.
 
 Synthesis: the digest prose is produced by a headless `claude -p` pass over a
 deterministic context packet. If the synth call fails or returns empty, the
@@ -179,6 +179,10 @@ def digest_path(date_iso: str, period: str = "morning") -> pathlib.Path:
 
 def manifest_path(date_iso: str, period: str = "morning") -> pathlib.Path:
     return ORCH / f"{period}-digest-{date_iso}.json"
+
+
+def notebooklm_manifest_path(date_iso: str, period: str = "morning") -> pathlib.Path:
+    return ORCH / f"{period}-digest-{date_iso}-notebooklm.json"
 
 
 def speech_path(date_iso: str, period: str = "morning") -> pathlib.Path:
@@ -1273,6 +1277,16 @@ def load_notebooklm_manifest(path: pathlib.Path) -> dict[str, Any]:
         }
 
 
+def ensure_notebooklm_manifest(date_iso: str, period: str) -> pathlib.Path:
+    """Give NotebookLM one stable manifest, importing legacy state once."""
+    target = notebooklm_manifest_path(date_iso, period)
+    if not target.is_file():
+        legacy = load_notebooklm_manifest(manifest_path(date_iso, period))
+        if legacy:
+            save_manifest(target, legacy)
+    return target
+
+
 def _ensure_notebook(manifest: dict[str, Any]) -> str:
     existing = manifest.get("notebook_id")
     if isinstance(existing, str) and existing:
@@ -1374,7 +1388,7 @@ def push_notebooklm(
         save_manifest(mpath, manifest)
         log(f"{date_iso}: NotebookLM failed softly: {exc}")
         print(f"NotebookLM failed softly (kept file): {exc}")
-        return 0
+        return 1
 
 
 
@@ -1861,12 +1875,11 @@ def acquire_lock(date_iso: str, period: str = "morning"):
 # Background runtime guard (spec D4, defense in depth)
 # ---------------------------------------------------------------------------
 
-# Scheduled runs may reach local TTS/Telegram only as one of these process ids launched
+# Scheduled runs may reach audio handlers only as one of these process ids launched
 # with EXACTLY this argv. kb-tick execs the configured `run` command with no
 # extra argv, so a legitimate scheduled run compares equal after basename
 # normalization of argv[0]. The config validator in _kb_processes is the first
-# gate; this in-process guard also catches a scheduled caller that OMITS
-# telegram_audio from its declared outputs (invisible to that validator).
+# gate; channel selection itself is the independent outputs flag map.
 BACKGROUND_ALLOWLIST = {
     "morning-digest": ["kb-morning-digest"],
     "evening-digest": ["kb-morning-digest", "--period", "evening"],
@@ -1892,34 +1905,27 @@ def background_push_denied() -> str | None:
     argv = [os.path.basename(sys.argv[0])] + sys.argv[1:]
     if argv != allowed_argv:
         return f"argv {argv!r} does not match the allowlisted command for {process_id!r}"
-    outputs = [o.strip() for o in os.environ.get("KB_PROCESS_OUTPUTS", "").split(",")]
-    if outputs not in (
-        ["file", "notebooklm_audio"], ["file", "telegram_audio"],
-    ):
-        return (
-            "KB_PROCESS_OUTPUTS must be exactly file,notebooklm_audio or "
-            "file,telegram_audio"
-        )
     return None
 
 
-def selected_audio_backend() -> str:
-    """Return the delivery adapter after the background guard accepted argv.
+def selected_audio_channels() -> list[str]:
+    """Return every independently enabled audio channel.
 
     Manual test runs keep the already shipped local-Qwen behavior. Production
-    scheduled runs select only through the validated outputs declaration.
+    scheduled runs read the normalized true flags from KB_PROCESS_OUTPUTS.
     """
     if os.environ.get("KB_PROCESS_ID") is None:
-        return "local_qwen"
+        return ["telegram_audio"]
     outputs = [o.strip() for o in os.environ.get("KB_PROCESS_OUTPUTS", "").split(",")]
-    if outputs == ["file", "notebooklm_audio"]:
-        return "notebooklm"
-    return "local_qwen"
+    return [
+        channel for channel in ("telegram_audio", "notebooklm_audio")
+        if channel in outputs
+    ]
 
 
 def build_ready_digest(
     date_iso: str, period: str, digest_file: pathlib.Path | None,
-    morning_input: dict[str, Any] | None = None,
+    morning_input: dict[str, Any] | None = None
 ) -> tuple[dict[str, pathlib.Path], str, str | None]:
     """Generate the report once and freeze the exact text passed to adapters.
 
@@ -1974,19 +1980,26 @@ def build_ready_digest(
 def run_notebooklm_route(
     date_iso: str, period: str, digest_file: pathlib.Path | None,
     out_path: pathlib.Path, mpath: pathlib.Path, force: bool,
+    prepared: bool = False,
 ) -> int:
-    """Build the unchanged current report, then invoke only NotebookLM."""
+    """Send the canonical speech file to NotebookLM, building it when needed."""
     existing = load_notebooklm_manifest(mpath)
     if not force and existing.get("status") == "completed" \
             and existing.get("artifact_id"):
         print(f"already completed for {date_iso}: artifact={existing.get('artifact_id')}")
         return 0
 
-    paths, source, build_error = build_ready_digest(
-        date_iso, period, digest_file,
-    )
+    if prepared:
+        paths = canonical_artifacts(date_iso, period)
+        source, build_error = "shared-build", None
+        if not paths["report"].is_file() or not paths["speech"].is_file():
+            build_error = "shared speech file is unavailable"
+    else:
+        paths, source, build_error = build_ready_digest(
+            date_iso, period, digest_file,
+        )
     if paths["report"] != out_path:
-        raise RuntimeError("NotebookLM selector requires the canonical report path")
+        raise RuntimeError("NotebookLM delivery requires the canonical report path")
     if build_error is not None:
         log(f"{date_iso}: {source} remains report-only: {build_error}")
         return 1
@@ -2011,6 +2024,197 @@ def run_notebooklm_route(
 # ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
+
+def run_local_route(
+    date_iso: str, period: str, digest_file: pathlib.Path | None,
+    mpath: pathlib.Path, force: bool, background_allowed: bool,
+) -> int:
+    """Run the existing local Qwen → Telegram handler."""
+    morning_input: dict[str, Any] | None = None
+    manifest, blocked = load_local_manifest(mpath, date_iso, period, force)
+    if blocked:
+        _append_failure_log(date_iso, period, manifest)
+        return 0
+
+    if force:
+        # Explicit owner recovery must be able to replace even a locally
+        # corrupted semantic/counter schema.  Reuse only independently
+        # hash-verified canonical speech; never trust attempts/caps/state.
+        reusable_speech = _speech_valid(manifest, date_iso, period)
+        legacy = manifest.get("legacy") if isinstance(manifest.get("legacy"), dict) else None
+        manifest = fresh_manifest(date_iso, period, legacy)
+        if reusable_speech:
+            paths = canonical_artifacts(date_iso, period)
+            manifest.update({
+                "status": "report_ready",
+                "speech_sha256": file_sha256(paths["speech"]),
+                "updated_at": now_iso(),
+            })
+            save_manifest(mpath, manifest)
+            return render_and_send(date_iso, period, mpath, manifest, True)
+    else:
+        # Exact schema/caps are persisted invariants, not ambient
+        # configuration.  Without explicit force, corruption fails closed
+        # before gather, TTS or Telegram.
+        attempts = manifest.get("attempts")
+        caps = manifest.get("caps")
+        if (not isinstance(attempts, dict) or caps != ATTEMPT_CAPS
+                or not _manifest_semantics_valid(manifest) or any(
+            isinstance(attempts.get(key), bool)
+            or not isinstance(attempts.get(key), int) or attempts.get(key) < 0
+            for key in ("build", "tts", "telegram", "total")
+        )):
+            return _set_integrity_failure(
+                mpath, manifest, date_iso, period,
+                "invalid attempts/caps manifest schema",
+            )
+
+        status = manifest.get("status")
+        disposition = manifest.get("retry_disposition")
+        if status == "telegram_sending":
+            manifest.update({
+                "status": "telegram_ambiguous", "failed_stage": "telegram",
+                "retry_disposition": "force_required",
+                "error": "previous run stopped after Telegram transmission may have begun",
+                "updated_at": now_iso(),
+            })
+            save_manifest(mpath, manifest)
+            _append_failure_log(date_iso, period, manifest)
+            return 0
+        if status == "completed":
+            message_id = (manifest.get("telegram") or {}).get("message_id")
+            if not message_id:
+                return _set_integrity_failure(
+                    mpath, manifest, date_iso, period,
+                    "completed manifest is missing telegram.message_id",
+                )
+            if period != "morning":
+                print(f"already completed for {date_iso}: message_id={message_id}")
+                return 0
+
+            stored_snapshot = manifest.get("upstream_snapshot")
+            if (
+                isinstance(stored_snapshot, dict)
+                and stored_snapshot.get("schema") == "morning-input/v1"
+            ):
+                # Input-contract upgrade (EXACTLY v1→v2, D13: mail/board
+                # left the roster): a completed delivery built under the
+                # known previous contract is NOT corrupt — treat it exactly
+                # like the pre-v0.6 no-provenance case below (manual no-op;
+                # the exact scheduler caller upgrades the manifest once).
+                # Any OTHER schema (malformed, future) falls through to
+                # snapshot_valid and fails closed as integrity corruption.
+                stored_snapshot = None
+            exact_scheduled = bool(
+                os.environ.get("KB_PROCESS_BACKGROUND")
+                and os.environ.get("KB_PROCESS_ID") == "morning-digest"
+                and background_allowed
+            )
+            if stored_snapshot is None and not exact_scheduled:
+                # Compatibility: an old/local manifest without v0.6 input
+                # provenance remains a manual no-op.  The exact scheduler
+                # caller upgrades it once so a pre-chain smoke cannot occupy
+                # the real post-chain slot.
+                print(f"already completed for {date_iso}: message_id={message_id}")
+                return 0
+            if stored_snapshot is not None and not snapshot_valid(stored_snapshot):
+                return _set_integrity_failure(
+                    mpath, manifest, date_iso, period,
+                    f"invalid {SNAPSHOT_SCHEMA} upstream_snapshot",
+                )
+
+            morning_input = capture_morning_input(date_iso)
+            current_snapshot = morning_input["upstream_snapshot"]
+            if (
+                stored_snapshot is not None
+                and stored_snapshot["semantic_sha256"]
+                == current_snapshot["semantic_sha256"]
+            ):
+                print(f"already completed for {date_iso}: message_id={message_id}")
+                return 0
+
+            previous = {
+                "message_id": message_id,
+                "semantic_sha256": (
+                    stored_snapshot.get("semantic_sha256")
+                    if isinstance(stored_snapshot, dict) else None
+                ),
+                "completed_at": manifest.get("updated_at"),
+            }
+            legacy = manifest.get("legacy") if isinstance(manifest.get("legacy"), dict) else None
+            manifest = fresh_manifest(date_iso, period, legacy)
+            manifest.update({
+                "upstream_snapshot": current_snapshot,
+                "superseded_delivery": previous,
+                "updated_at": now_iso(),
+            })
+            save_manifest(mpath, manifest)
+            status = manifest["status"]
+            disposition = manifest["retry_disposition"]
+            log(f"{date_iso}: completed morning delivery superseded by newer semantic input")
+        if disposition in ("terminal", "force_required") or status in (
+            "unavailable", "telegram_ambiguous",
+        ):
+            print(f"delivery state {status}/{disposition}; --force required for recovery")
+            return 0
+        failed_stage = manifest.get("failed_stage")
+        if status == "failed" and failed_stage in ("build", "tts", "telegram"):
+            if _block_at_cap(mpath, manifest, failed_stage, date_iso, period):
+                return 0
+        if status == "report_ready" or (status == "failed" and failed_stage == "tts"):
+            if not _speech_valid(manifest, date_iso, period):
+                return _set_integrity_failure(
+                    mpath, manifest, date_iso, period,
+                    "stored report/speech path or speech hash failed validation",
+                )
+            return render_and_send(date_iso, period, mpath, manifest, True)
+        if status in ("tts_rendered", "telegram_failed") or (
+            status == "failed" and failed_stage == "telegram"
+        ):
+            if not _speech_valid(manifest, date_iso, period):
+                return _set_integrity_failure(
+                    mpath, manifest, date_iso, period,
+                    "stored report/speech path or speech hash failed validation",
+                )
+            return render_and_send(
+                date_iso, period, mpath, manifest, not _audio_valid(manifest, date_iso, period)
+            )
+
+    if period == "morning" and morning_input is None:
+        morning_input = capture_morning_input(date_iso)
+    if morning_input is not None:
+        manifest["upstream_snapshot"] = morning_input["upstream_snapshot"]
+
+    if _block_at_cap(mpath, manifest, "build", date_iso, period):
+        return 0
+    _begin_attempt(mpath, manifest, "build", "started")
+
+    paths = canonical_artifacts(date_iso, period)
+    for stale in (paths["speech"], paths["audio"]):
+        try:
+            stale.unlink()
+        except OSError:
+            pass
+
+    paths, source, build_error = build_ready_digest(
+        date_iso, period, digest_file, morning_input,
+    )
+    if build_error is not None:
+        return _stage_failed(
+            mpath, manifest, "build", date_iso, period, build_error,
+        )
+    manifest.update({
+        "status": "report_ready", "retry_disposition": "retryable",
+        "failed_stage": None, "speech_sha256": file_sha256(paths["speech"]),
+        "audio_sha256": None, "telegram": None, "error": None,
+        "updated_at": now_iso(),
+    })
+    save_manifest(mpath, manifest)
+    rc = render_and_send(date_iso, period, mpath, manifest, True)
+    if manifest.get("status") == "completed":
+        append_hub_log(date_iso, paths["report"], manifest, period)
+    return rc
+
 
 def run(date_iso: str, *, period: str, digest_file: pathlib.Path | None,
         out: pathlib.Path | None, no_push: bool, force: bool) -> int:
@@ -2053,8 +2257,8 @@ def run(date_iso: str, *, period: str, digest_file: pathlib.Path | None,
 
     try:
         denied = background_push_denied()
-        delivery_enabled = not no_push and out is None and denied is None
-        backend = selected_audio_backend() if delivery_enabled else None
+        channels = selected_audio_channels() if not no_push and out is None else []
+        delivery_enabled = not no_push and out is None and denied is None and bool(channels)
         morning_input: dict[str, Any] | None = None
 
         # Compatibility/file-only paths deliberately do not inspect or mutate
@@ -2093,194 +2297,21 @@ def run(date_iso: str, *, period: str, digest_file: pathlib.Path | None,
                 print("skipped local audio delivery (--no-push/--out)")
             return 0
 
-        if backend == "notebooklm":
-            return run_notebooklm_route(
-                date_iso, period, digest_file, out_path, mpath, force,
-            )
-
-        manifest, blocked = load_local_manifest(mpath, date_iso, period, force)
-        if blocked:
-            _append_failure_log(date_iso, period, manifest)
-            return 0
-
-        if force:
-            # Explicit owner recovery must be able to replace even a locally
-            # corrupted semantic/counter schema.  Reuse only independently
-            # hash-verified canonical speech; never trust attempts/caps/state.
-            reusable_speech = _speech_valid(manifest, date_iso, period)
-            legacy = manifest.get("legacy") if isinstance(manifest.get("legacy"), dict) else None
-            manifest = fresh_manifest(date_iso, period, legacy)
-            if reusable_speech:
-                paths = canonical_artifacts(date_iso, period)
-                manifest.update({
-                    "status": "report_ready",
-                    "speech_sha256": file_sha256(paths["speech"]),
-                    "updated_at": now_iso(),
-                })
-                save_manifest(mpath, manifest)
-                return render_and_send(date_iso, period, mpath, manifest, True)
-        else:
-            # Exact schema/caps are persisted invariants, not ambient
-            # configuration.  Without explicit force, corruption fails closed
-            # before gather, TTS or Telegram.
-            attempts = manifest.get("attempts")
-            caps = manifest.get("caps")
-            if (not isinstance(attempts, dict) or caps != ATTEMPT_CAPS
-                    or not _manifest_semantics_valid(manifest) or any(
-                isinstance(attempts.get(key), bool)
-                or not isinstance(attempts.get(key), int) or attempts.get(key) < 0
-                for key in ("build", "tts", "telegram", "total")
-            )):
-                return _set_integrity_failure(
-                    mpath, manifest, date_iso, period,
-                    "invalid attempts/caps manifest schema",
-                )
-
-            status = manifest.get("status")
-            disposition = manifest.get("retry_disposition")
-            if status == "telegram_sending":
-                manifest.update({
-                    "status": "telegram_ambiguous", "failed_stage": "telegram",
-                    "retry_disposition": "force_required",
-                    "error": "previous run stopped after Telegram transmission may have begun",
-                    "updated_at": now_iso(),
-                })
-                save_manifest(mpath, manifest)
-                _append_failure_log(date_iso, period, manifest)
-                return 0
-            if status == "completed":
-                message_id = (manifest.get("telegram") or {}).get("message_id")
-                if not message_id:
-                    return _set_integrity_failure(
-                        mpath, manifest, date_iso, period,
-                        "completed manifest is missing telegram.message_id",
-                    )
-                if period != "morning":
-                    print(f"already completed for {date_iso}: message_id={message_id}")
-                    return 0
-
-                stored_snapshot = manifest.get("upstream_snapshot")
-                if (
-                    isinstance(stored_snapshot, dict)
-                    and stored_snapshot.get("schema") == "morning-input/v1"
-                ):
-                    # Input-contract upgrade (EXACTLY v1→v2, D13: mail/board
-                    # left the roster): a completed delivery built under the
-                    # known previous contract is NOT corrupt — treat it exactly
-                    # like the pre-v0.6 no-provenance case below (manual no-op;
-                    # the exact scheduler caller upgrades the manifest once).
-                    # Any OTHER schema (malformed, future) falls through to
-                    # snapshot_valid and fails closed as integrity corruption.
-                    stored_snapshot = None
-                exact_scheduled = bool(
-                    os.environ.get("KB_PROCESS_BACKGROUND")
-                    and os.environ.get("KB_PROCESS_ID") == "morning-digest"
-                    and denied is None
-                )
-                if stored_snapshot is None and not exact_scheduled:
-                    # Compatibility: an old/local manifest without v0.6 input
-                    # provenance remains a manual no-op.  The exact scheduler
-                    # caller upgrades it once so a pre-chain smoke cannot occupy
-                    # the real post-chain slot.
-                    print(f"already completed for {date_iso}: message_id={message_id}")
-                    return 0
-                if stored_snapshot is not None and not snapshot_valid(stored_snapshot):
-                    return _set_integrity_failure(
-                        mpath, manifest, date_iso, period,
-                        f"invalid {SNAPSHOT_SCHEMA} upstream_snapshot",
-                    )
-
-                morning_input = capture_morning_input(date_iso)
-                current_snapshot = morning_input["upstream_snapshot"]
-                if (
-                    stored_snapshot is not None
-                    and stored_snapshot["semantic_sha256"]
-                    == current_snapshot["semantic_sha256"]
-                ):
-                    print(f"already completed for {date_iso}: message_id={message_id}")
-                    return 0
-
-                previous = {
-                    "message_id": message_id,
-                    "semantic_sha256": (
-                        stored_snapshot.get("semantic_sha256")
-                        if isinstance(stored_snapshot, dict) else None
-                    ),
-                    "completed_at": manifest.get("updated_at"),
-                }
-                legacy = manifest.get("legacy") if isinstance(manifest.get("legacy"), dict) else None
-                manifest = fresh_manifest(date_iso, period, legacy)
-                manifest.update({
-                    "upstream_snapshot": current_snapshot,
-                    "superseded_delivery": previous,
-                    "updated_at": now_iso(),
-                })
-                save_manifest(mpath, manifest)
-                status = manifest["status"]
-                disposition = manifest["retry_disposition"]
-                log(f"{date_iso}: completed morning delivery superseded by newer semantic input")
-            if disposition in ("terminal", "force_required") or status in (
-                "unavailable", "telegram_ambiguous",
-            ):
-                print(f"delivery state {status}/{disposition}; --force required for recovery")
-                return 0
-            failed_stage = manifest.get("failed_stage")
-            if status == "failed" and failed_stage in ("build", "tts", "telegram"):
-                if _block_at_cap(mpath, manifest, failed_stage, date_iso, period):
-                    return 0
-            if status == "report_ready" or (status == "failed" and failed_stage == "tts"):
-                if not _speech_valid(manifest, date_iso, period):
-                    return _set_integrity_failure(
-                        mpath, manifest, date_iso, period,
-                        "stored report/speech path or speech hash failed validation",
-                    )
-                return render_and_send(date_iso, period, mpath, manifest, True)
-            if status in ("tts_rendered", "telegram_failed") or (
-                status == "failed" and failed_stage == "telegram"
-            ):
-                if not _speech_valid(manifest, date_iso, period):
-                    return _set_integrity_failure(
-                        mpath, manifest, date_iso, period,
-                        "stored report/speech path or speech hash failed validation",
-                    )
-                return render_and_send(
-                    date_iso, period, mpath, manifest, not _audio_valid(manifest, date_iso, period)
-                )
-
-        if period == "morning" and morning_input is None:
-            morning_input = capture_morning_input(date_iso)
-        if morning_input is not None:
-            manifest["upstream_snapshot"] = morning_input["upstream_snapshot"]
-
-        if _block_at_cap(mpath, manifest, "build", date_iso, period):
-            return 0
-        _begin_attempt(mpath, manifest, "build", "started")
-
-        paths = canonical_artifacts(date_iso, period)
-        for stale in (paths["speech"], paths["audio"]):
-            try:
-                stale.unlink()
-            except OSError:
-                pass
-
-        paths, source, build_error = build_ready_digest(
-            date_iso, period, digest_file, morning_input,
-        )
-        if build_error is not None:
-            return _stage_failed(
-                mpath, manifest, "build", date_iso, period, build_error,
-            )
-        manifest.update({
-            "status": "report_ready", "retry_disposition": "retryable",
-            "failed_stage": None, "speech_sha256": file_sha256(paths["speech"]),
-            "audio_sha256": None, "telegram": None, "error": None,
-            "updated_at": now_iso(),
-        })
-        save_manifest(mpath, manifest)
-        rc = render_and_send(date_iso, period, mpath, manifest, True)
-        if manifest.get("status") == "completed":
-            append_hub_log(date_iso, paths["report"], manifest, period)
-        return rc
+        notebook_mpath = ensure_notebooklm_manifest(date_iso, period)
+        handlers = {
+            "telegram_audio": lambda: run_local_route(
+                date_iso, period, digest_file, mpath, force, denied is None,
+            ),
+            "notebooklm_audio": lambda: run_notebooklm_route(
+                date_iso, period, digest_file, out_path, notebook_mpath, force,
+                prepared=out_path.is_file() and speech_path(date_iso, period).is_file(),
+            ),
+        }
+        retry = False
+        for channel in channels:
+            if handlers[channel]() != 0:
+                retry = True
+        return 1 if retry else 0
     finally:
         if lock_fh is not None:
             lock_fh.close()
@@ -2288,7 +2319,7 @@ def run(date_iso: str, *, period: str, digest_file: pathlib.Path | None,
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Morning/evening digest -> selected NotebookLM or local-Qwen audio route."
+        description="Morning/evening digest -> enabled audio channels."
     )
     parser.add_argument("--period", choices=("morning", "evening"), default="morning",
                         help="Which digest to build (default morning).")

--- a/bin/tests/test-digest-migration.sh
+++ b/bin/tests/test-digest-migration.sh
@@ -3,7 +3,7 @@
 # (after:retro) and morning-digest anchored to the LAST enabled SCHEDULED
 # morning process (money-radar > learning > daily), re-anchors ONLY its own
 # managed morning-digest block when a better anchor appears, preserves the
-# selected backend unless `--audio-backend` explicitly changes it, leaves customized
+# independent output flags, leaves customized
 # blocks byte-identical, preserves every other process/edge, is idempotent,
 # fails closed on malformed input, and --revert round-trips.
 #
@@ -176,14 +176,42 @@ CP="$TMP/d.before"; cp "$F" "$CP"
 "$MIG" --file "$F" >/dev/null 2>&1
 cmp -s "$F" "$CP" && ok "d: second run after re-anchor is a no-op" || fail "d: re-anchor not idempotent"
 
+# A boolean-map block remains managed regardless of which channel flags are on.
+F2="$TMP/d-flags.yaml"
+{ fixture absent enabled; cat <<'EOF'
+
+- id: morning-digest
+  enabled: true
+  when: after:learning
+  run: kb-morning-digest
+  outputs: {file: true, telegram_audio: true, notebooklm_audio: true}
+
+- id: evening-digest
+  enabled: true
+  when: after:retro
+  run: kb-morning-digest --period evening
+  outputs: {file: true, telegram_audio: true, notebooklm_audio: false}
+
+- id: money-radar
+  enabled: true
+  when: after:learning
+  run: kb-money-radar --text-only
+  outputs: [telegram, file]
+EOF
+} > "$F2"
+MORNING_FLAGS_BEFORE=$(awk '/^- id: morning-digest$/{f=1} f && /^  outputs:/{print; exit}' "$F2")
+"$MIG" --file "$F2" >/dev/null 2>&1; RC=$?
+MORNING_FLAGS_AFTER=$(awk '/^- id: morning-digest$/{f=1} f && /^  outputs:/{print; exit}' "$F2")
+[[ $RC -eq 0 && "$(anchor_of "$F2")" == "after:money-radar" \
+   && "$MORNING_FLAGS_BEFORE" == "$MORNING_FLAGS_AFTER" ]] \
+  && ok "d: channel flags stay managed and re-anchor without rewriting outputs" \
+  || fail "d: channel flags were treated as a hardcoded/custom combination"
+
+CP="$TMP/d.no-selector"; cp "$F" "$CP"
 "$MIG" --file "$F" --audio-backend local_qwen >/dev/null 2>&1; RC=$?
-[[ $RC -eq 0 && $(grep -c '^  outputs: \[file, telegram_audio\]$' "$F") -eq 2 ]] \
-  && ok "d: explicit local_qwen selects Telegram audio" \
-  || fail "d: explicit local_qwen did not switch managed outputs"
-"$MIG" --file "$F" --audio-backend notebooklm >/dev/null 2>&1; RC=$?
-[[ $RC -eq 0 && $(grep -c '^  outputs: \[file, notebooklm_audio\]$' "$F") -eq 2 ]] \
-  && ok "d: explicit notebooklm selects NotebookLM audio" \
-  || fail "d: explicit notebooklm did not restore managed outputs"
+[[ $RC -eq 2 && $(cmp -s "$F" "$CP"; echo $?) -eq 0 ]] \
+  && ok "d: legacy audio-backend selector is removed; outputs stay untouched" \
+  || fail "d: second delivery setting still exists or changed outputs"
 
 # ── (e) customized morning-digest block stays byte-identical ─────────────────
 F="$TMP/e.yaml"
@@ -196,7 +224,7 @@ F="$TMP/e.yaml"
   outputs: [file]
 EOF
 } > "$F"
-"$MIG" --file "$F" --audio-backend local_qwen >/dev/null 2>&1; RC=$?
+"$MIG" --file "$F" >/dev/null 2>&1; RC=$?
 [[ $RC -eq 0 ]] && ok "e: migrate with customized block exits 0" || fail "e: rc=$RC"
 [[ "$(anchor_of "$F")" == '"05:00"' ]] \
   && ok "e: customized morning-digest left untouched (when unchanged)" \

--- a/bin/tests/test-local-tts-digest-integration.sh
+++ b/bin/tests/test-local-tts-digest-integration.sh
@@ -713,7 +713,7 @@ run_scheduled_synth "$H" >/dev/null 2>&1; MAIL_RC=$?
   || bad "snapshot surface: mail rc=$MAIL_RC unexpectedly resent"
 unset KB_TEST_VEPOL_DEV
 
-# ── 9. Selector: same synthesized text, exactly one delivery adapter ─────────
+# ── 9. Independent channel flags: same synthesized text ─────────────────────
 HQ="$TMP/selector-qwen"; HN="$TMP/selector-notebooklm"; D=$(date +%F)
 make_hub "$HQ"; make_hub "$HN"
 printf '%s\n' 'SNAPSHOT_SELECTOR_SAME_TEXT' >"$HQ/.orchestrator/money-radar-$D-codex-out.txt"
@@ -725,14 +725,14 @@ run_scheduled_notebooklm_synth "$HN" >/dev/null 2>&1; NRC=$?
    && $(grep -c 'NOTEBOOKLM_CALLED generate audio' "$HN/notebooklm.log") -eq 1 \
    && $(grep -c "NOTEBOOKLM_CALLED source add $HN/reports/morning-digest-$D.txt " \
         "$HN/notebooklm.log") -eq 1 ]] \
-  && ok "selector: each outputs choice invokes exactly one delivery adapter" \
-  || bad "selector: backend calls crossed or selected route failed"
+  && ok "channel flags: each true output invokes its handler" \
+  || bad "channel flags: handler calls crossed or failed"
 cmp -s "$HQ/reports/morning-digest-$D.txt" "$HN/reports/morning-digest-$D.txt" \
-  && ok "selector: ready digest text is identical before delivery" \
-  || bad "selector: route changed the synthesized digest text"
+  && ok "channel flags: ready digest text is identical before delivery" \
+  || bad "channel flags: channel changed the synthesized digest text"
 
-# Switching adapters with an existing foreign manifest must start only the
-# newly selected adapter, never crash on the other adapter's counter schema.
+# Toggling flags keeps one stable manifest per handler and never repeats a
+# handler that already completed for the date.
 HS="$TMP/selector-switch"; make_hub "$HS"
 printf '%s\n' 'SNAPSHOT_SELECTOR_SWITCH' >"$HS/.orchestrator/money-radar-$D-codex-out.txt"
 run_scheduled_synth "$HS" >/dev/null 2>&1; Q1=$?
@@ -740,10 +740,10 @@ run_scheduled_notebooklm_synth "$HS" >/dev/null 2>&1; N1=$?
 SENDS_AFTER_N=$(wc -l <"$HS/send.log")
 run_scheduled_synth "$HS" >/dev/null 2>&1; Q2=$?
 [[ $Q1 -eq 0 && $N1 -eq 0 && $Q2 -eq 0 && $SENDS_AFTER_N -eq 1 \
-   && $(wc -l <"$HS/send.log") -eq 2 \
+   && $(wc -l <"$HS/send.log") -eq 1 \
    && $(grep -c 'NOTEBOOKLM_CALLED generate audio' "$HS/notebooklm.log") -eq 1 ]] \
-  && ok "selector: existing foreign manifest switches safely in both directions" \
-  || bad "selector: backend switch crashed or crossed delivery adapters"
+  && ok "channel flags: toggles preserve stable per-handler manifests" \
+  || bad "channel flags: toggle repeated or crossed handlers"
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/bin/tests/test-processes-audio-allowlist.sh
+++ b/bin/tests/test-processes-audio-allowlist.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Scheduler audio allowlist + runtime guard (selectable digest audio delivery):
+# Scheduler audio flags + runtime guard:
 # scheduled `telegram_audio` or `notebooklm_audio` passes ONLY for the digest processes with their
 # EXACT run commands (id+command binding — same ids with a different run are
 # rejected; any other id stays fail-closed), DEFAULT_PROCESSES_YAML wires both
@@ -105,9 +105,38 @@ EOF
   enabled: true
   when: after:learning
   run: kb-morning-digest
-  outputs: [file, notebooklm_audio, telegram_audio]
+  outputs: {file: true, telegram_audio: true, notebooklm_audio: true}
 EOF
-} | check_yaml invalid "managed digest cannot select both audio routes"
+} | check_yaml valid "managed digest accepts independent true channel flags"
+
+python3 - "$SRC_BIN" <<'PY' && ok "AC4: boolean output map keeps only true channels" \
+                            || fail "AC4: boolean output map parsing failed"
+import sys
+sys.path.insert(0, sys.argv[1])
+from _kb_processes import parse_processes_text
+
+base = """\
+- id: morning-digest
+  enabled: true
+  when: on-demand
+  run: kb-morning-digest
+  outputs: {file: true, telegram_audio: %s, notebooklm_audio: %s}
+"""
+assert parse_processes_text(base % ("true", "false"))[0]["outputs"] == ["file", "telegram_audio"]
+assert parse_processes_text(base % ("false", "true"))[0]["outputs"] == ["file", "notebooklm_audio"]
+assert parse_processes_text(base % ("true", "true"))[0]["outputs"] == ["file", "telegram_audio", "notebooklm_audio"]
+assert parse_processes_text(base % ("false", "false"))[0]["outputs"] == ["file"]
+PY
+
+{ base_procs; cat <<'EOF'
+
+- id: morning-digest
+  enabled: true
+  when: after:learning
+  run: kb-morning-digest
+  outputs: {file: true, telegram_audo: false, notebooklm_audio: true}
+EOF
+} | check_yaml invalid "unknown false channel is rejected"
 
 { base_procs; cat <<'EOF'
 
@@ -335,9 +364,10 @@ mk_hub() { # $1 = dir
   : > "$1/personal/.secrets"
   printf '{"fixture":true}\n' >"$1/tts/install.json"
   printf '## Retro (20:45)\n\nguard-fixture retro.\n' > "$1/briefs/$DAY.md"
-  cat >"$1/bin/kb-tts-render" <<'SH'
+cat >"$1/bin/kb-tts-render" <<'SH'
 #!/usr/bin/env bash
 echo "render $*" >>"$AUDIOLOG"
+[[ "${FAIL_TTS:-0}" == "1" ]] && exit 1
 out=''; while [[ $# -gt 0 ]]; do case "$1" in --out) out="$2"; shift 2;; *) shift;; esac; done
 printf 'ID3-guard-audio' >"$out"
 SH
@@ -353,6 +383,7 @@ AUDIOLOG="$TMP/guard-audio.log"; : > "$AUDIOLOG"
 cat > "$TMP/fake-notebooklm" <<FAKE
 #!/usr/bin/env bash
 echo "\$*" >> "$NBLOG"
+if [[ "\${FAIL_NLM:-0}" == "1" && "\$1 \${2:-}" == "generate audio" ]]; then exit 1; fi
 case "\$1 \${2:-}" in
   "list --json"*|"list "*) echo '{"notebooks": []}' ;;
   "create "*)              echo '{"id": "nb-fake-1"}' ;;
@@ -422,12 +453,68 @@ guard_run "$H" "evening-digest" "file,notebooklm_audio" --period evening; RC=$?
   && ok "AC4: legitimate background evening-digest -> NotebookLM only" \
   || fail "AC4: NotebookLM route did not stay isolated (rc=$RC)"
 
-# 7. Manual run (no background vars) unaffected -> local render + send happens.
+# 7. Both flags call both existing handlers with the same frozen speech path.
 H="$TMP/g7"; mk_hub "$H"; : > "$NBLOG"; : > "$AUDIOLOG"
+guard_run "$H" "evening-digest" "file,telegram_audio,notebooklm_audio" --period evening; RC=$?
+TTS_TEXT=$(sed -n 's/^render .*--file \([^ ]*\).*/\1/p' "$AUDIOLOG" | head -1)
+NLM_TEXT=$(sed -n 's/^source add \([^ ]*\).*/\1/p' "$NBLOG" | head -1)
+[[ $RC -eq 0 && $(grep -c '^render ' "$AUDIOLOG") -eq 1 \
+   && $(grep -c '^send ' "$AUDIOLOG") -eq 1 \
+   && $(grep -c '^generate audio' "$NBLOG") -eq 1 \
+   && -n "$TTS_TEXT" && "$TTS_TEXT" == "$NLM_TEXT" ]] \
+  && ok "AC4: both true -> both handlers receive one frozen speech path" \
+  || fail "AC4: both-channel fan-out failed (rc=$RC, tts=$TTS_TEXT, nlm=$NLM_TEXT)"
+
+# 8. A first-handler failure does not suppress the second handler.
+H="$TMP/g8"; mk_hub "$H"; : > "$NBLOG"; : > "$AUDIOLOG"
+FAIL_TTS=1 guard_run "$H" "evening-digest" "file,telegram_audio,notebooklm_audio" --period evening; RC=$?
+[[ $RC -ne 0 && $(grep -c '^render ' "$AUDIOLOG") -eq 1 \
+   && $(grep -c '^send ' "$AUDIOLOG") -eq 0 \
+   && $(grep -c '^generate audio' "$NBLOG") -eq 1 ]] \
+  && ok "AC4: local failure still dispatches NotebookLM and returns retry" \
+  || fail "AC4: first-handler failure suppressed NotebookLM (rc=$RC)"
+
+# 9. Manual run (no background vars) unaffected -> local render + send happens.
+H="$TMP/g9"; mk_hub "$H"; : > "$NBLOG"; : > "$AUDIOLOG"
 guard_run "$H" "-" "-" --period evening; RC=$?
 [[ $RC -eq 0 && $(grep -c '^render ' "$AUDIOLOG") -eq 1 && $(grep -c '^send ' "$AUDIOLOG") -eq 1 && ! -s "$NBLOG" ]] \
   && ok "AC4: fully manual run unaffected by the guard" \
   || fail "AC4: manual run was wrongly blocked (rc=$RC)"
+
+# 10. Channel toggles never change the manifest owned by a successful handler.
+H="$TMP/g10"; mk_hub "$H"; : > "$NBLOG"; : > "$AUDIOLOG"
+guard_run "$H" "evening-digest" "file,notebooklm_audio" --period evening; RC1=$?
+guard_run "$H" "evening-digest" "file,telegram_audio,notebooklm_audio" --period evening; RC2=$?
+guard_run "$H" "evening-digest" "file,notebooklm_audio" --period evening; RC3=$?
+[[ $RC1 -eq 0 && $RC2 -eq 0 && $RC3 -eq 0 \
+   && $(grep -c '^generate audio' "$NBLOG") -eq 1 \
+   && $(grep -c '^render ' "$AUDIOLOG") -eq 1 \
+   && -f "$H/.orchestrator/evening-digest-$DAY.json" \
+   && -f "$H/.orchestrator/evening-digest-$DAY-notebooklm.json" ]] \
+  && ok "AC4: single/both toggles keep stable per-channel manifests" \
+  || fail "AC4: channel toggle repeated a completed handler"
+
+# 11. Telegram success + NotebookLM retry only retries NotebookLM.
+H="$TMP/g11"; mk_hub "$H"; : > "$NBLOG"; : > "$AUDIOLOG"
+FAIL_NLM=1 guard_run "$H" "evening-digest" "file,telegram_audio,notebooklm_audio" --period evening; RC1=$?
+guard_run "$H" "evening-digest" "file,telegram_audio,notebooklm_audio" --period evening; RC2=$?
+[[ $RC1 -ne 0 && $RC2 -eq 0 \
+   && $(grep -c '^render ' "$AUDIOLOG") -eq 1 \
+   && $(grep -c '^send ' "$AUDIOLOG") -eq 1 \
+   && $(grep -c '^generate audio' "$NBLOG") -eq 2 ]] \
+  && ok "AC4: retry invokes only failed NotebookLM handler" \
+  || fail "AC4: NotebookLM retry repeated Telegram"
+
+# 12. NotebookLM success + Telegram retry only retries Telegram.
+H="$TMP/g12"; mk_hub "$H"; : > "$NBLOG"; : > "$AUDIOLOG"
+FAIL_TTS=1 guard_run "$H" "evening-digest" "file,telegram_audio,notebooklm_audio" --period evening; RC1=$?
+guard_run "$H" "evening-digest" "file,telegram_audio,notebooklm_audio" --period evening; RC2=$?
+[[ $RC1 -ne 0 && $RC2 -eq 0 \
+   && $(grep -c '^render ' "$AUDIOLOG") -eq 2 \
+   && $(grep -c '^send ' "$AUDIOLOG") -eq 1 \
+   && $(grep -c '^generate audio' "$NBLOG") -eq 1 ]] \
+  && ok "AC4: retry invokes only failed Telegram handler" \
+  || fail "AC4: Telegram retry repeated NotebookLM"
 
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]] || exit 1

--- a/bin/tests/test-tts-distribution.sh
+++ b/bin/tests/test-tts-distribution.sh
@@ -67,29 +67,24 @@ else
 fi
 
 if [[ ! -f "$PUBLIC/install.sh" ]]; then
-  ok "audio-backend installer setting not applicable to this standalone root"
-elif grep -q -- '--audio-backend' "$PUBLIC/install.sh" \
-  && grep -q 'local_qwen' "$PUBLIC/install.sh" \
-  && grep -q 'notebooklm' "$PUBLIC/install.sh"; then
-  ok "installer exposes NotebookLM/local-Qwen audio backend selection"
+  ok "installer channel-setting check not applicable to this standalone root"
 else
-  bad "installer has no explicit dual-backend setting"
-fi
-
-if [[ -f "$PUBLIC/install.sh" ]]; then
+  if grep -q -- '--audio-backend' "$PUBLIC/install.sh"; then
+    bad "installer still exposes a second audio-backend setting"
+  else
+    ok "outputs map is the only installer delivery setting"
+  fi
   CAPS=$("$PUBLIC/install.sh" --capabilities --json 2>/dev/null); RC=$?
-  [[ $RC -eq 0 && "$CAPS" == *'"audio_backends": ["notebooklm", "local_qwen"]'* ]] \
-    && ok "installer capabilities advertise both backend values" \
-    || bad "installer capabilities omit the backend values"
-  "$PUBLIC/install.sh" --capabilities --audio-backend invalid >/dev/null 2>&1; RC=$?
+  [[ $RC -eq 0 && "$CAPS" != *'"audio_backends"'* ]] \
+    && ok "installer capabilities have no backend selector" \
+    || bad "installer capabilities still advertise backend selector"
+  "$PUBLIC/install.sh" --capabilities --audio-backend local_qwen >/dev/null 2>&1; RC=$?
   [[ $RC -eq 2 ]] \
-    && ok "installer rejects an invalid backend before mutation" \
-    || bad "installer accepted an invalid backend (rc=$RC)"
+    && ok "legacy audio-backend option is rejected" \
+    || bad "legacy audio-backend option is still accepted (rc=$RC)"
 fi
 
-# Behavioral installer matrix in an isolated HOME against the exact staged
-# release artifact. Fake Qwen install records the route it observed, proving
-# model smoke happens before the managed outputs switch.
+# Fresh install writes one boolean output map; upgrades preserve user flags.
 if [[ -n "$ARTIFACT_TMP" ]]; then
   CASE="$ARTIFACT_TMP/install-case"; HOME_CASE="$CASE/home"; FAKEBIN="$CASE/fakebin"
   mkdir -p "$HOME_CASE" "$FAKEBIN"
@@ -100,77 +95,27 @@ if [[ -n "$ARTIFACT_TMP" ]]; then
   printf '#!/bin/sh\necho 1.1.0\n' >"$FAKEBIN/bun"; chmod +x "$FAKEBIN/bun"
   INSTALL_ENV=(HOME="$HOME_CASE" PATH="$FAKEBIN:$PATH" VEPOL_NONINTERACTIVE=1)
 
-  env "${INSTALL_ENV[@]}" "$PUBLIC/install.sh" --apply \
-    >/dev/null 2>&1; RC=$?
+  env "${INSTALL_ENV[@]}" "$PUBLIC/install.sh" --apply >/dev/null 2>&1; RC=$?
   CONFIG="$HOME_CASE/knowledge/personal/processes.yaml"
-  [[ $RC -eq 0 && $(grep -c '^  outputs: \[file, notebooklm_audio\]$' "$CONFIG") -eq 2 ]] \
-    && ok "fresh installer default writes NotebookLM route" \
-    || bad "fresh installer default did not write NotebookLM route (rc=$RC)"
-
-  cat >"$PUBLIC/bin/kb-tts-install" <<'SH'
-#!/usr/bin/env bash
-set -u
-config="$HOME/knowledge/personal/processes.yaml"
-if grep -q '^  outputs: \[file, notebooklm_audio\]$' "$config"; then
-  echo observed_notebooklm >>"$HOME/tts-install-order.log"
-else
-  echo observed_other >>"$HOME/tts-install-order.log"
-fi
-[[ "${KB_FAKE_TTS_INSTALL_MODE:-success}" == success ]]
-SH
-  chmod +x "$PUBLIC/bin/kb-tts-install"
-  env "${INSTALL_ENV[@]}" KB_FAKE_TTS_INSTALL_MODE=success \
-    "$PUBLIC/install.sh" --apply --audio-backend local_qwen >/dev/null 2>&1; RC=$?
-  [[ $RC -eq 0 && $(grep -c '^observed_notebooklm$' "$HOME_CASE/tts-install-order.log") -eq 1 \
-     && $(grep -c '^  outputs: \[file, telegram_audio\]$' "$CONFIG") -eq 2 ]] \
-    && ok "Qwen install succeeds before managed outputs switch" \
-    || bad "Qwen installer ordering/selection is wrong (rc=$RC)"
+  [[ $RC -eq 0 && $(grep -c '^  outputs: {file: true, telegram_audio: false, notebooklm_audio: true}$' "$CONFIG") -eq 2 ]] \
+    && ok "fresh installer writes one boolean output map" \
+    || bad "fresh installer output map is wrong (rc=$RC)"
 
   cp "$CONFIG" "$CASE/preserve.before"
   env "${INSTALL_ENV[@]}" "$PUBLIC/install.sh" --apply >/dev/null 2>&1; RC=$?
   [[ $RC -eq 0 ]] && cmp -s "$CONFIG" "$CASE/preserve.before" \
-    && ok "upgrade without selection preserves managed config byte-identical" \
-    || bad "upgrade without selection changed managed config"
-
-  env "${INSTALL_ENV[@]}" "$PUBLIC/install.sh" --apply --audio-backend notebooklm \
-    >/dev/null 2>&1
-  cp "$CONFIG" "$CASE/failure.before"
-  env "${INSTALL_ENV[@]}" KB_FAKE_TTS_INSTALL_MODE=failure \
-    "$PUBLIC/install.sh" --apply --audio-backend local_qwen >/dev/null 2>&1; RC=$?
-  [[ $RC -ne 0 ]] && cmp -s "$CONFIG" "$CASE/failure.before" \
-    && ok "failed Qwen install leaves prior route byte-identical" \
-    || bad "failed Qwen install changed the prior route"
-
-  python3 - "$CONFIG" <<'PY'
-import pathlib, sys
-path = pathlib.Path(sys.argv[1]); lines = path.read_text().splitlines()
-active = None
-for i, line in enumerate(lines):
-    if line == "- id: morning-digest": active = "morning"
-    elif line == "- id: evening-digest": active = "evening"
-    elif line.startswith("- id: "): active = None
-    elif active and line.startswith("  run:"):
-        lines[i] = "  run: kb-morning-digest --custom-operator-route"
-    elif active and line.startswith("  outputs:"):
-        lines[i] = "  outputs: [file]"
-path.write_text("\n".join(lines) + "\n")
-PY
-  cp "$CONFIG" "$CASE/custom.before"
-  env "${INSTALL_ENV[@]}" KB_FAKE_TTS_INSTALL_MODE=success \
-    "$PUBLIC/install.sh" --apply --audio-backend local_qwen >/dev/null 2>&1; RC=$?
-  [[ $RC -eq 0 ]] && cmp -s "$CONFIG" "$CASE/custom.before" \
-    && ok "installer leaves customized digest blocks byte-identical" \
-    || bad "installer rewrote customized digest blocks"
+    && ok "upgrade preserves output flags byte-identical" \
+    || bad "upgrade changed output flags"
 fi
 
 if [[ ! -f "$PUBLIC/README.md" || ! -f "$PUBLIC/CHANGELOG.md" ]]; then
   ok "public guidance check not applicable to this standalone root"
-elif grep -Fq 'kb-tts-install' "$PUBLIC/README.md" \
-   && grep -Fq 'NotebookLM' "$PUBLIC/README.md" \
-   && grep -Fq 'local Qwen' "$PUBLIC/CHANGELOG.md"; then
-  ok "public guidance documents both selectable audio routes"
+elif grep -Fq 'telegram_audio: true' "$PUBLIC/README.md" \
+   && grep -Fq 'notebooklm_audio: true' "$PUBLIC/README.md" \
+   && ! grep -q -- '--audio-backend' "$PUBLIC/README.md"; then
+  ok "public guidance documents the single boolean output map"
 else
-  bad "public guidance does not document both audio routes"
+  bad "public guidance does not document the boolean output map"
 fi
 
 SEED_INSTALL="${KB_TTS_SEED_INSTALL:-$(cd "$SEED/.." 2>/dev/null && pwd)/install.sh}"

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ fi
 # agent can detect "this installer is too old for prompt-first install" instead
 # of silently running a full install. (spec: agent-self-install, blockers B1/B2/B3)
 # ─────────────────────────────────────────
-MODE=""; WANT_JSON=0; AUDIO_BACKEND=""
+MODE=""; WANT_JSON=0
 _set_mode() {  # reject conflicting mode flags (e.g. --probe --apply) — exit 2, empty stdout
   if [[ -n "$MODE" && "$MODE" != "$1" ]]; then
     printf 'install.sh: conflicting mode flags (%s and %s)\n' "$MODE" "$1" >&2
@@ -62,10 +62,6 @@ while [[ $# -gt 0 ]]; do
     --capabilities) _set_mode capabilities ;;
     --apply)        _set_mode apply ;;
     --json)         WANT_JSON=1 ;;
-    --audio-backend)
-      [[ $# -ge 2 ]] || { printf 'install.sh: --audio-backend requires notebooklm or local_qwen\n' >&2; exit 2; }
-      AUDIO_BACKEND="$2"; shift ;;
-    --audio-backend=*) AUDIO_BACKEND="${arg#*=}" ;;
     -h|--help)      _set_mode help ;;
     *) printf 'install.sh: unknown option: %s\n' "$arg" >&2
        printf 'Run "./install.sh --capabilities --json" to see supported modes.\n' >&2
@@ -73,11 +69,6 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
-if [[ -n "$AUDIO_BACKEND" && "$AUDIO_BACKEND" != "notebooklm" \
-      && "$AUDIO_BACKEND" != "local_qwen" ]]; then
-  printf 'install.sh: invalid --audio-backend: %s (expected notebooklm or local_qwen)\n' "$AUDIO_BACKEND" >&2
-  exit 2
-fi
 [[ -z "$MODE" ]] && MODE="apply-interactive"
 
 _json_esc() {  # minimal JSON string escaping for shell-emitted JSON (backslash, quote)
@@ -94,7 +85,6 @@ _emit_capabilities() {
   "schema_version": 1,
   "modes": ["--probe", "--dry-run", "--apply", "--verify", "--capabilities", "--help"],
   "json_modes": ["--probe", "--dry-run", "--verify", "--capabilities"],
-  "audio_backends": ["notebooklm", "local_qwen"],
   "opt_in_env": ["VEPOL_ENABLE_LAUNCHD", "VEPOL_ENABLE_TELEGRAM", "VEPOL_ENABLE_MEMORY_COMPILER", "VEPOL_APPLY_C01"],
   "exit_codes": {"0": "ok", "2": "unknown-option", "10": "missing-required-prereq", "11": "partial-install", "12": "plan-conflict", "13": "verify-failed"}
 }
@@ -247,8 +237,6 @@ Usage:
   ./install.sh --dry-run --json      Plan only (no mutation).
   ./install.sh --verify --json       Check an existing install.
   ./install.sh --capabilities --json List supported modes.
-  ./install.sh --apply --audio-backend notebooklm|local_qwen
-                                      Select the managed digest audio route.
 
 Opt-in env for --apply (all default OFF):
   VEPOL_ENABLE_LAUNCHD=1   scheduled background tasks
@@ -316,17 +304,6 @@ ask() {
   read -r answer
   [[ "$answer" =~ ^[Yy]$ ]]
 }
-
-# A new interactive install offers one simple route choice. Existing installs
-# are never switched or prompted on upgrade unless --audio-backend is explicit.
-if [[ "$MODE" == "apply-interactive" && -z "$AUDIO_BACKEND" \
-      && ! -f "$HUB/personal/processes.yaml" ]]; then
-  if ask "Use local Qwen for digest audio and send MP3 to Telegram? (No keeps NotebookLM)"; then
-    AUDIO_BACKEND="local_qwen"
-  else
-    AUDIO_BACKEND="notebooklm"
-  fi
-fi
 
 # ─────────────────────────────────────────
 # Header
@@ -662,8 +639,7 @@ PROFEOF
   ok "  $HUB/personal/profile.yaml created (language: $_locale_lang — edit to change)"
 fi
 
-# Managed digest route. Creating the default config is safe and idempotent;
-# upgrades without an explicit selection preserve the existing outputs exactly.
+# Managed digest flags. The outputs map is the only delivery setting.
 PROCESSES_FILE="$HUB/personal/processes.yaml"
 if [[ ! -f "$PROCESSES_FILE" ]]; then
   python3 - "$HUB/bin" "$PROCESSES_FILE" <<'PY'
@@ -672,18 +648,10 @@ sys.path.insert(0, sys.argv[1])
 from _kb_processes import load_processes
 load_processes(pathlib.Path(sys.argv[2]), create_default=True)
 PY
-  ok "  $PROCESSES_FILE created (audio backend: notebooklm)"
+  ok "  $PROCESSES_FILE created"
 fi
-if [[ "$AUDIO_BACKEND" == "local_qwen" ]]; then
-  "$HUB/bin/kb-tts-install"
-  "$HUB/bin/kb-digest-migrate" --file "$PROCESSES_FILE" --audio-backend local_qwen
-  ok "  digest audio backend: local Qwen → Telegram"
-elif [[ "$AUDIO_BACKEND" == "notebooklm" ]]; then
-  "$HUB/bin/kb-digest-migrate" --file "$PROCESSES_FILE" --audio-backend notebooklm
-  ok "  digest audio backend: NotebookLM"
-else
-  ok "  existing digest audio backend preserved"
-fi
+"$HUB/bin/kb-digest-migrate" --file "$PROCESSES_FILE"
+ok "  digest output flags preserved"
 
 # ─────────────────────────────────────────
 # Step 3. Global ~/.claude/CLAUDE.md (include-pattern)


### PR DESCRIPTION
## What changed

- Make `outputs` the single delivery setting: every known boolean channel flag is dispatched independently.
- Remove the audio-backend selector and the whitelist of allowed channel combinations.
- Preserve legacy output lists during migration while keeping boolean maps untouched.
- Build one frozen speech input and pass it to the enabled local Qwen/Telegram and NotebookLM handlers.
- Update installer defaults, migration behavior, documentation, and regression coverage.

## Why

The previous selector/combination model encoded specific sets of destinations. That made independent toggles harder to reason about and harder to extend. A channel now has one rule: `true` sends there; `false` does not.

## User impact

Morning and evening digests can enable Telegram audio and NotebookLM audio independently from the same `outputs` map. One handler failing does not prevent the other enabled handler from being attempted, and successful per-channel retries remain stable.

## Validation

- channel flags: 36/36
- digest migration: 28/28
- local digest integration: 110/110
- evening digest: 39/39
- distribution: 14/14
- `git diff --check`: clean

## Stacked PR

This PR targets `agent/russian-morning-tts-prompt` so its diff contains only the two reviewed channel-flag commits. After PR #3 merges, this PR can be retargeted to `main`.
